### PR TITLE
cicd: run redis in ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,12 +12,13 @@ jobs:
       fail-fast: false
       matrix:
         rustver: ['1.85.1', stable]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rustver }}
+      - run: docker compose -f env/docker-compose.yml up -d
       - run: cargo test -- --show-output
 
   cover:
@@ -34,5 +35,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rustver }}
           components: llvm-tools-preview
+      - run: docker compose -f env/docker-compose.yml up -d
       - run: cargo install cargo-llvm-cov
       - run: cargo llvm-cov

--- a/env/docker-compose.yml
+++ b/env/docker-compose.yml
@@ -1,0 +1,8 @@
+# https://hub.docker.com/r/redislabs/redis/tags
+
+services:
+  redis:
+    container_name: redis_local
+    image: redis:8
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
This PR adds running redis in github actions configuration file.

Since it seems that GitHub Actions only supports Docker on Ubuntu, this PR changes to run CI on ubuntu only.