### PR TITLE
chore: added msrv task in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,6 +51,11 @@ doc() {
   errcheck $?
 }
 
+msrv() {
+  cargo msrv find --ignore-lockfile --no-check-feedback
+  errcheck $?
+}
+
 if [[ "$#" == "0" ]]; then
   #clean
   format
@@ -86,8 +91,8 @@ else
     bench)
       bench
       ;;
-    '')
-      compile
+    msrv)
+      msrv
       ;;
     *)
       echo "Bad task: $a"


### PR DESCRIPTION
This PR adds an `msrv` task in `build.sh` to specify certain options for getting the desired result from `cargo-msrv`.