### PR TITLE
refactor: modified RedisDataConn have a pool and RedisDataConn#get_connection get conn from pool

### DIFF
--- a/src/standalone.rs
+++ b/src/standalone.rs
@@ -227,7 +227,7 @@ mod test_redis {
     trait RedisSampleDataAcc: DataAcc {
         fn get_sample_key(&mut self) -> Result<Option<String>, Err> {
             let redis_dc = self.get_data_conn::<RedisDataConn>("redis")?;
-            let mut conn = redis_dc.get_connection().unwrap();
+            let mut conn = redis_dc.get_connection()?;
             let rslt: redis::RedisResult<Option<String>> = conn.get("sample");
             return match rslt {
                 Ok(opt) => Ok(opt),
@@ -236,7 +236,7 @@ mod test_redis {
         }
         fn set_sample_key(&mut self, val: &str) -> Result<(), Err> {
             let redis_dc = self.get_data_conn::<RedisDataConn>("redis")?;
-            let mut conn = redis_dc.get_connection().unwrap();
+            let mut conn = redis_dc.get_connection()?;
             return match conn.set("sample", val) {
                 Ok(()) => Ok(()),
                 Err(e) => Err(Err::with_source(SampleError::FailToSetValue, e)),
@@ -244,7 +244,7 @@ mod test_redis {
         }
         fn del_sample_key(&mut self) -> Result<(), Err> {
             let redis_dc = self.get_data_conn::<RedisDataConn>("redis")?;
-            let mut conn = redis_dc.get_connection().unwrap();
+            let mut conn = redis_dc.get_connection()?;
             return match conn.del("sample") {
                 Ok(()) => Ok(()),
                 Err(e) => Err(Err::with_source(SampleError::FailToDelValue, e)),
@@ -253,7 +253,7 @@ mod test_redis {
 
         fn set_sample_key_with_force_back(&mut self, val: &str) -> Result<(), Err> {
             let redis_dc = self.get_data_conn::<RedisDataConn>("redis")?;
-            let mut conn = redis_dc.get_connection().unwrap();
+            let mut conn = redis_dc.get_connection()?;
 
             if let Err(e) = conn.set::<&str, &str, ()>("sample_force_back", val) {
                 return Err(Err::with_source(SampleError::FailToSetValue, e));


### PR DESCRIPTION
This PR modifies `RedisDataConn#get_connection` to retrieve a connection from `r2d2::Pool<RedlisClient>`, not to get a same connection instance that was created along with the `RedisDataConn`.

In the previous implementation, while the borrow of the `conn: redis::Connection` instance obtained from `RedisDataConn#get_connection` was active, you couldn't call the `RedisDataConn#add_force_back method`. To perform multiple operations and register force-back functions alternately, you had to enclose the `conn` acquisition and operations in a block. After the block ended and the `conn` was dropped, you could then execute `add_force_back`, and then repeat the process of acquiring the `conn` and performing operations inside another block.
In the new implementation, it's possible to execute operations on the `conn` and `add_force_back` alternately.

Also, in the previous implementation, it was impossible to handle a connection that was severed while being passed around. With the new implementation, however, the pool automatically reconnects, allowing you to get an active connection by calling `RedisDataConn::get_connection`.
However, if all connections are in use, there will be an overhead of waiting until a connection is released.
