### PR TITLE
update!: made a feature for standalone and synchronous commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,14 @@ categories = ["database"]
 
 [dependencies]
 errs = "0.2"
-r2d2 = "0.8"
-redis = { version = "0.32", features = ["r2d2"] }
+r2d2 = { version = "0.8", optional = true }
+redis = { version = "0.32" }
 sabi-rust = "0.4"
 
 [dev-dependencies]
 override_macro = "0.1"
+
+[features]
+default = ["sabi_redis-standalone-sync"]
+
+sabi_redis-standalone-sync = ["dep:r2d2", "redis/r2d2"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,5 +129,7 @@
 //! }
 //! ```
 
+#[cfg(feature = "sabi_redis-standalone-sync")]
 mod standalone;
+#[cfg(feature = "sabi_redis-standalone-sync")]
 pub use standalone::{RedisDataConn, RedisDataSrc, RedisDataSrcError};

--- a/tests/standalone_sync_test.rs
+++ b/tests/standalone_sync_test.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "sabi_redis-standalone-sync")]
 #[cfg(test)]
 mod integration_tests_of_sabi_redis {
     use errs;


### PR DESCRIPTION
This PR make a feature `sabi_redis-standalone-sync` for `RedisDataSrc` and `RedisDataConn` that are for Redis standalone server and synchronous commands.

This `sabi_redis-standalone-sync` feature is the default.