### PR TITLE
cicd: updated ci target rust versions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rustver: ['1.87.0', '1.89.0', '1.93.1']
+        rustver: ['1.87.0', '1.89.0', '1.94.0']
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
This PR adds 1.94.0 to CI target Rust versions.