### PR TITLE
update!: refined the constructor arguments of each DataSrc struct

### DIFF
--- a/src/cluster_sync.rs
+++ b/src/cluster_sync.rs
@@ -5,6 +5,7 @@
 use sabi::{AsyncGroup, DataConn, DataSrc};
 
 use redis::cluster::{ClusterClient, ClusterClientBuilder, ClusterConnection};
+use redis::IntoConnectionInfo;
 
 use std::fmt::Debug;
 use std::{mem, time};
@@ -224,50 +225,54 @@ impl DataConn for RedisClusterDataConn {
 /// Manages a connection pool for a Redis Cluster data source.
 ///
 /// This struct is responsible for setting up the Redis Cluster connection pool
-/// using a `redis::cluster::ClusterClient` and creating new `RedisClusterDataConn` instances from the pool.
+/// using a `ClusterClient` and creating new `RedisClusterDataConn` instances from the pool.
+///
+/// `RedisClusterDataSrc` implements the `DataSrc` trait, allowing it to be used within a `DataHub`.
 pub struct RedisClusterDataSrc {
     pool: Option<RedisPool>,
 }
 
 enum RedisPool {
     Object(r2d2::Pool<ClusterClient>),
-    ClientBuilder(Box<ClusterClientBuilder>, r2d2::Builder<ClusterClient>),
+    Builder(Box<ClusterClientBuilder>, r2d2::Builder<ClusterClient>),
 }
 
 impl RedisClusterDataSrc {
-    /// Creates a new `RedisClusterDataSrc` instance.
+    /// Creates a new `RedisClusterDataSrc` instance with the specified Redis Cluster addresses.
     ///
-    /// The connection information for initial nodes is stored, but the connection pool is not built
-    /// until the `setup` method is called.
-    ///
-    /// - `initial_nodes`: An iterator of connection information for the initial Cluster nodes (e.g., "redis://127.0.0.1:7000").
-    pub fn new<T: redis::IntoConnectionInfo>(initial_nodes: impl IntoIterator<Item = T>) -> Self {
-        let builder = ClusterClientBuilder::new(initial_nodes);
+    /// The `addrs` parameter can be an iterator of connection strings
+    /// (e.g., `vec!["redis://127.0.0.1:7000/", "redis://127.0.0.1:7001/"]`).
+    pub fn new<I, T>(addrs: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: IntoConnectionInfo,
+    {
+        let builder = ClusterClientBuilder::new(addrs);
         Self {
-            pool: Some(RedisPool::ClientBuilder(
-                Box::new(builder),
+            pool: Some(RedisPool::Builder(Box::new(builder), r2d2::Pool::builder())),
+        }
+    }
+
+    /// Creates a new `RedisClusterDataSrc` instance using an existing `ClusterClientBuilder`.
+    pub fn with_client_builder(client_builder: ClusterClientBuilder) -> Self {
+        Self {
+            pool: Some(RedisPool::Builder(
+                Box::new(client_builder),
                 r2d2::Pool::builder(),
             )),
         }
     }
 
-    /// Creates a new `RedisClusterDataSrc` instance with a pre-configured `ClusterClientBuilder`
-    /// and a custom `r2d2::Pool::builder`.
+    /// Creates a new `RedisClusterDataSrc` instance using an existing `ClusterClientBuilder`
+    /// and a custom pool builder.
     ///
-    /// This provides fine-grained control over both the Redis Cluster client details
-    /// and the connection pool's configuration.
-    ///
-    /// - `client_builder`: A `ClusterClientBuilder` instance.
-    /// - `pool_builder`: A custom `r2d2::Pool::builder` to configure the connection pool.
-    pub fn with_client_and_pool_builder(
+    /// This allows for fine-tuning the connection pool settings.
+    pub fn with_client_builder_and_pool_builder(
         client_builder: ClusterClientBuilder,
         pool_builder: r2d2::Builder<ClusterClient>,
     ) -> Self {
         Self {
-            pool: Some(RedisPool::ClientBuilder(
-                Box::new(client_builder),
-                pool_builder,
-            )),
+            pool: Some(RedisPool::Builder(Box::new(client_builder), pool_builder)),
         }
     }
 }
@@ -283,7 +288,7 @@ impl DataSrc<RedisClusterDataConn> for RedisClusterDataSrc {
         let pool =
             pool_opt.ok_or_else(|| errs::Err::new(RedisClusterDataSrcError::AlreadySetup))?;
         match pool {
-            RedisPool::ClientBuilder(conn_builder, pool_builder) => {
+            RedisPool::Builder(conn_builder, pool_builder) => {
                 let client = conn_builder.build().map_err(|e| {
                     errs::Err::with_source(RedisClusterDataSrcError::FailToBuildClient, e)
                 })?;
@@ -480,7 +485,7 @@ mod tests_of_cluster_sync {
         let mut data = DataHub::new();
         data.uses(
             "redis",
-            RedisClusterDataSrc::with_client_and_pool_builder(client_builder, pool_builder),
+            RedisClusterDataSrc::with_client_builder_and_pool_builder(client_builder, pool_builder),
         );
         data.run(sample_logic)?;
         Ok(())

--- a/src/sentinel_async.rs
+++ b/src/sentinel_async.rs
@@ -2,14 +2,11 @@
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
-use deadpool_redis::sentinel::{
-    Config, Connection, Pool, PoolConfig, Runtime, SentinelNodeConnectionInfo, SentinelServerType,
-};
-use deadpool_redis::ConnectionInfo;
+use deadpool_redis::sentinel::{Config, Connection, Pool, PoolConfig, Runtime, SentinelServerType};
 use sabi::tokio::{AsyncGroup, DataConn, DataSrc};
 
 use std::future::Future;
-use std::{fmt, mem, pin};
+use std::{mem, pin};
 
 /// Errors that can occur when using `RedisSentinelAsyncDataSrc` or `RedisSentinelAsyncDataConn`.
 #[derive(Debug)]
@@ -20,10 +17,6 @@ pub enum RedisSentinelAsyncDataSrcError {
     /// Indicates that an attempt was made to set up `RedisSentinelAsyncDataSrc` when it was already set up,
     /// or to set the internal pool when it was already set.
     AlreadySetup,
-
-    /// Indicates a failure to convert the `redis::ConnectionInfo` into
-    /// `deadpool_redis::ConnectionInfo`.
-    FailToConvertConnectionInfo,
 
     /// Indicates a failure to build the Redis connection pool.
     FailToBuildPool,
@@ -243,113 +236,74 @@ impl DataConn for RedisSentinelAsyncDataConn {
     }
 }
 
-/// `RedisSentinelAsyncDataSrc` serves as an asynchronous data source for Redis Sentinel,
-/// implementing the `DataSrc` trait from the `sabi::tokio` library. It manages the
-/// creation and lifecycle of a `deadpool_redis` connection pool configured for Sentinel.
+/// Manages an asynchronous connection pool for a Redis data source managed by Redis Sentinel.
 ///
-/// `T` is a type that can be converted into `redis::ConnectionInfo`.
-pub struct RedisSentinelAsyncDataSrc<T>
-where
-    T: redis::IntoConnectionInfo,
-{
-    pool: Option<RedisPool<T>>,
+/// This struct is responsible for setting up the Redis Sentinel connection pool
+/// using `deadpool_redis` and creating new `RedisSentinelAsyncDataConn` instances from the pool.
+///
+/// `RedisSentinelAsyncDataSrc` implements the `DataSrc` trait from `sabi::tokio`, allowing it to be
+/// used within an asynchronous `DataHub`.
+pub struct RedisSentinelAsyncDataSrc {
+    pool: Option<RedisPool>,
 }
 
-enum RedisPool<T>
-where
-    T: redis::IntoConnectionInfo,
-{
+enum RedisPool {
     Object(Pool),
-    Config(
-        Vec<T>,
-        String,
-        Option<SentinelNodeConnectionInfo>,
-        Option<PoolConfig>,
-    ),
+    Config(Box<Config>),
 }
 
-impl<T> RedisSentinelAsyncDataSrc<T>
-where
-    T: redis::IntoConnectionInfo + Sized + fmt::Debug,
-{
-    /// Creates a new `RedisSentinelAsyncDataSrc` with the specified sentinel URLs and master name.
+impl RedisSentinelAsyncDataSrc {
+    /// Creates a new `RedisSentinelAsyncDataSrc` instance with the specified Sentinel addresses
+    /// and master name.
     ///
-    /// The actual connection pool is built during the `setup_async` call.
-    ///
-    /// # Arguments
-    /// - `sentinels`: A list of sentinel node connection info (e.g., URL strings).
-    /// - `master_name`: The name of the Redis master group.
-    ///
-    /// # Returns
-    /// A new `RedisSentinelAsyncDataSrc` instance.
-    pub fn new(sentinels: Vec<T>, master_name: impl AsRef<str>) -> Self {
+    /// The `addrs` parameter is a list of Sentinel connection strings, and `master_name` is the
+    /// name of the master group (e.g., "mymaster").
+    pub fn new(addrs: Vec<impl AsRef<str>>, master_name: impl AsRef<str>) -> Self {
+        let urls = addrs.into_iter().map(|s| s.as_ref().to_string()).collect();
         Self {
-            pool: Some(RedisPool::Config(
-                sentinels,
-                master_name.as_ref().to_string(),
-                None,
-                None,
-            )),
+            pool: Some(RedisPool::Config(Box::new(Config {
+                urls: Some(urls),
+                server_type: SentinelServerType::Master,
+                master_name: master_name.as_ref().to_string(),
+                connections: None,
+                node_connection_info: None,
+                pool: None,
+            }))),
         }
     }
 
-    /// Creates a new `RedisSentinelAsyncDataSrc` with the specified sentinel URLs, master name,
-    /// and node connection information.
+    /// Creates a new `RedisSentinelAsyncDataSrc` instance with the specified Sentinel addresses,
+    /// master name, and custom pool configuration.
     ///
-    /// # Arguments
-    /// - `sentinels`: A list of sentinel node connection info.
-    /// - `master_name`: The name of the Redis master group.
-    /// - `info`: Connection information for the nodes managed by the sentinel.
-    ///
-    /// # Returns
-    /// A new `RedisSentinelAsyncDataSrc` instance.
-    pub fn with_node_connection_info(
-        sentinels: Vec<T>,
+    /// This allows for fine-tuning the connection pool settings.
+    pub fn with_addrs_and_master_name_and_pool_config(
+        addrs: Vec<impl AsRef<str>>,
         master_name: impl AsRef<str>,
-        info: SentinelNodeConnectionInfo,
-    ) -> Self {
-        Self {
-            pool: Some(RedisPool::Config(
-                sentinels,
-                master_name.as_ref().to_string(),
-                Some(info),
-                None,
-            )),
-        }
-    }
-
-    /// Creates a new `RedisSentinelAsyncDataSrc` with the specified sentinel URLs, master name,
-    /// node connection information, and pool configuration.
-    ///
-    /// # Arguments
-    /// - `sentinels`: A list of sentinel node connection info.
-    /// - `master_name`: The name of the Redis master group.
-    /// - `info`: Connection information for the nodes managed by the sentinel.
-    /// - `pool_config`: Custom configuration for the connection pool.
-    ///
-    /// # Returns
-    /// A new `RedisSentinelAsyncDataSrc` instance.
-    pub fn with_node_connection_info_and_pool_config(
-        sentinels: Vec<T>,
-        master_name: impl AsRef<str>,
-        info: SentinelNodeConnectionInfo,
         pool_config: PoolConfig,
     ) -> Self {
+        let urls = addrs.into_iter().map(|s| s.as_ref().to_string()).collect();
         Self {
-            pool: Some(RedisPool::Config(
-                sentinels,
-                master_name.as_ref().to_string(),
-                Some(info),
-                Some(pool_config),
-            )),
+            pool: Some(RedisPool::Config(Box::new(Config {
+                urls: Some(urls),
+                server_type: SentinelServerType::Master,
+                master_name: master_name.as_ref().to_string(),
+                connections: None,
+                node_connection_info: None,
+                pool: Some(pool_config),
+            }))),
+        }
+    }
+
+    /// Creates a new `RedisSentinelAsyncDataSrc` instance using an existing
+    /// `deadpool_redis::sentinel::Config`.
+    pub fn with_config(cfg: Config) -> Self {
+        Self {
+            pool: Some(RedisPool::Config(Box::new(cfg))),
         }
     }
 }
 
-impl<T> DataSrc<RedisSentinelAsyncDataConn> for RedisSentinelAsyncDataSrc<T>
-where
-    T: redis::IntoConnectionInfo + Sized + Send + fmt::Debug,
-{
+impl DataSrc<RedisSentinelAsyncDataConn> for RedisSentinelAsyncDataSrc {
     /// Asynchronously sets up the Redis Sentinel connection pool.
     /// This method should be called once before attempting to create any
     /// `RedisSentinelAsyncDataConn` instances.
@@ -365,23 +319,7 @@ where
         let pool =
             pool_opt.ok_or_else(|| errs::Err::new(RedisSentinelAsyncDataSrcError::AlreadySetup))?;
         match pool {
-            RedisPool::Config(mut sentinels, master_name, node_conn_info_opt, pool_config_opt) => {
-                let vec = mem::take(&mut sentinels);
-                let conn_info_vec = vec
-                    .into_iter()
-                    .map(|p| p.into_connection_info().map(ConnectionInfo::from))
-                    .collect::<redis::RedisResult<Vec<ConnectionInfo>>>()
-                    .map_err(|e| {
-                        errs::Err::with_source(RedisSentinelAsyncDataSrcError::FailToBuildPool, e)
-                    })?;
-                let cfg = Config {
-                    urls: None,
-                    server_type: SentinelServerType::Master,
-                    master_name: master_name.to_string(),
-                    connections: Some(conn_info_vec),
-                    node_connection_info: node_conn_info_opt,
-                    pool: pool_config_opt,
-                };
+            RedisPool::Config(cfg) => {
                 let pool = cfg.create_pool(Some(Runtime::Tokio1)).map_err(|e| {
                     errs::Err::with_source(RedisSentinelAsyncDataSrcError::FailToBuildPool, e)
                 })?;
@@ -419,7 +357,7 @@ where
 #[cfg(test)]
 mod tests_of_sentinel_async {
     use super::*;
-    use deadpool_redis::{RedisConnectionInfo, Timeouts};
+    use deadpool_redis::Timeouts;
     use override_macro::{overridable, override_with};
     use redis::AsyncCommands;
     use sabi::tokio::{logic, DataAcc, DataHub};
@@ -611,37 +549,7 @@ mod tests_of_sentinel_async {
     }
 
     #[tokio::test]
-    async fn ok_with_node_connection_info() -> errs::Result<()> {
-        let mut redis_connection_info = RedisConnectionInfo::default();
-        redis_connection_info.db = 1;
-
-        let mut sentinel_node_connection_info = SentinelNodeConnectionInfo::default();
-        sentinel_node_connection_info.redis_connection_info = Some(redis_connection_info);
-
-        let ds = RedisSentinelAsyncDataSrc::with_node_connection_info(
-            vec![
-                "redis://127.0.0.1:26479",
-                "redis://127.0.0.1:26480",
-                "redis://127.0.0.1:26481",
-            ],
-            "mymaster",
-            sentinel_node_connection_info,
-        );
-
-        let mut data = DataHub::new();
-        data.uses("redis", ds);
-        data.run_async(logic!(sample_logic_async)).await?;
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn ok_with_node_connection_info_and_pool_config() -> errs::Result<()> {
-        let mut redis_connection_info = RedisConnectionInfo::default();
-        redis_connection_info.db = 1;
-
-        let mut sentinel_node_connection_info = SentinelNodeConnectionInfo::default();
-        sentinel_node_connection_info.redis_connection_info = Some(redis_connection_info);
-
+    async fn ok_by_sentinel_urls_and_pool_config() -> errs::Result<()> {
         let pool_config = PoolConfig {
             max_size: 10,
             timeouts: Timeouts {
@@ -652,19 +560,58 @@ mod tests_of_sentinel_async {
             ..Default::default()
         };
 
-        let ds = RedisSentinelAsyncDataSrc::with_node_connection_info_and_pool_config(
-            vec![
-                "redis://127.0.0.1:26479",
-                "redis://127.0.0.1:26480",
-                "redis://127.0.0.1:26481",
-            ],
-            "mymaster",
-            sentinel_node_connection_info,
-            pool_config,
+        let mut data = DataHub::new();
+        data.uses(
+            "redis",
+            RedisSentinelAsyncDataSrc::with_addrs_and_master_name_and_pool_config(
+                vec![
+                    "redis://127.0.0.1:26479",
+                    "redis://127.0.0.1:26480",
+                    "redis://127.0.0.1:26481",
+                ],
+                "mymaster",
+                pool_config,
+            ),
         );
+        data.run_async(logic!(sample_logic_async)).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ok_with_config() -> errs::Result<()> {
+        let pool_config = PoolConfig {
+            max_size: 10,
+            timeouts: Timeouts {
+                wait: Some(time::Duration::from_secs(10)),
+                create: Some(time::Duration::from_secs(11)),
+                recycle: Some(time::Duration::from_secs(12)),
+            },
+            ..Default::default()
+        };
+
+        let mut redis_connection_info = deadpool_redis::RedisConnectionInfo::default();
+        redis_connection_info.db = 1;
+
+        let mut sentinel_node_connection_info =
+            deadpool_redis::sentinel::SentinelNodeConnectionInfo::default();
+        sentinel_node_connection_info.redis_connection_info = Some(redis_connection_info);
+
+        let cfg = Config {
+            urls: vec![
+                "redis://127.0.0.1:26479".to_string(),
+                "redis://127.0.0.1:26480".to_string(),
+                "redis://127.0.0.1:26481".to_string(),
+            ]
+            .into(),
+            server_type: SentinelServerType::Master,
+            master_name: "mymaster".to_string(),
+            connections: None,
+            node_connection_info: Some(sentinel_node_connection_info),
+            pool: Some(pool_config),
+        };
 
         let mut data = DataHub::new();
-        data.uses("redis", ds);
+        data.uses("redis", RedisSentinelAsyncDataSrc::with_config(cfg));
         data.run_async(logic!(sample_logic_async)).await?;
         Ok(())
     }
@@ -693,17 +640,25 @@ mod tests_of_sentinel_async {
                             .1
                             .source()
                             .unwrap()
-                            .downcast_ref::<redis::RedisError>()
+                            .downcast_ref::<deadpool_redis::CreatePoolError>()
                             .unwrap();
-                        assert_eq!(e.kind(), redis::ErrorKind::InvalidClientConfig);
-                        assert!(e.detail().is_none());
-                        assert!(e.code().is_none());
-                        assert_eq!(e.category(), "invalid client config");
+                        match e {
+                            deadpool_redis::CreatePoolError::Config(ce) => match ce {
+                                deadpool_redis::ConfigError::Redis(re) => {
+                                    assert_eq!(re.kind(), redis::ErrorKind::InvalidClientConfig);
+                                    assert_eq!(re.detail(), None);
+                                    assert_eq!(re.code(), None);
+                                    assert_eq!(re.category(), "invalid client config");
+                                }
+                                _ => panic!(),
+                            },
+                            _ => panic!("{e:?}"),
+                        }
                     }
-                    _ => panic!("{:?}", err),
+                    _ => panic!("{err:?}"),
                 }
             } else {
-                panic!("{:?}", err)
+                panic!("{err:?}")
             }
         } else {
             panic!();

--- a/src/sentinel_sync.rs
+++ b/src/sentinel_sync.rs
@@ -18,16 +18,22 @@ use std::mem;
 pub enum RedisSentinelDataSrcError {
     /// Indicates that a connection was requested before `RedisSentinelDataSrc` was set up.
     NotSetupYet,
+
     /// Indicates that a setup operation was attempted on an already-configured `RedisSentinelDataSrc`.
     AlreadySetup,
+
     /// Indicates a failure to parse connection addresses.
     FailToParseConnectionAddrs,
+
     /// Indicates a failure to create `SentinelClientBuilder`.
     FailToCreateSentinelClientBuilder,
+
     /// Indicates a failure to build the Redis Sentinel connection pool.
     FailToBuildPool,
+
     /// Indicates a failure to build the `SentinelClient`.
     FailToBuildSentinelClient,
+
     /// Indicates a failure to get a Redis Sentinel connection from the pool.
     FailToGetConnectionFromPool,
 }
@@ -203,10 +209,12 @@ impl DataConn for RedisSentinelDataConn {
     fn close(&mut self) {}
 }
 
-/// Manages a connection pool for a Redis Sentinel data source.
+/// Manages a connection pool for a Redis data source managed by Redis Sentinel.
 ///
-/// This struct is responsible for setting up the Redis Sentinel connection pool
-/// using a `redis::sentinel::SentinelClient` and creating new `RedisSentinelDataConn` instances from the pool.
+/// This struct is responsible for setting up the Redis connection pool
+/// using a `SentinelClient` and creating new `RedisSentinelDataConn` instances from the pool.
+///
+/// `RedisSentinelDataSrc` implements the `DataSrc` trait, allowing it to be used within a `DataHub`.
 pub struct RedisSentinelDataSrc<T>
 where
     T: redis::IntoConnectionInfo,
@@ -219,113 +227,97 @@ where
     T: redis::IntoConnectionInfo,
 {
     Object(r2d2::Pool<LockedSentinelClient>),
-    Sentinel(
+    Client(
         Vec<T>,
         String,
         Option<SentinelNodeConnectionInfo>,
+        SentinelServerType,
         r2d2::Builder<LockedSentinelClient>,
     ),
-    SentinelClient(SentinelClientBuilder, r2d2::Builder<LockedSentinelClient>),
+    Builder(SentinelClientBuilder, r2d2::Builder<LockedSentinelClient>),
 }
 
 impl<T> RedisSentinelDataSrc<T>
 where
     T: redis::IntoConnectionInfo,
 {
-    /// Creates a new `RedisSentinelDataSrc` instance.
+    /// Creates a new `RedisSentinelDataSrc` instance with the specified Sentinel addresses and
+    /// service name.
     ///
-    /// The connection information for Sentinel nodes and the Redis service name are stored,
-    /// but the connection pool is not built until the `setup` method is called.
-    ///
-    /// - `sentinels`: A vector of connection information for the Sentinel nodes (e.g., "redis://127.0.0.1:26379").
-    /// - `service_name`: The name of the Redis master service to connect to (as configured in Sentinel).
-    pub fn new(sentinels: Vec<T>, service_name: &str) -> Self {
+    /// The `addrs` parameter is a list of Sentinel connection strings, and `service_name` is the
+    /// name of the master group (e.g., "mymaster").
+    pub fn new(addrs: Vec<T>, service_name: impl AsRef<str>) -> Self {
         Self {
-            pool: Some(RedisPool::Sentinel(
-                sentinels,
-                service_name.to_string(),
+            pool: Some(RedisPool::Client(
+                addrs,
+                service_name.as_ref().to_string(),
                 None,
+                SentinelServerType::Master,
                 r2d2::Pool::builder(),
             )),
         }
     }
 
-    /// Creates a new `RedisSentinelDataSrc` instance with specific node connection information.
+    /// Creates a new `RedisSentinelDataSrc` instance with detailed client information.
     ///
-    /// This allows configuring specific details for connecting to the Redis master,
-    /// such as database selection or password.
-    ///
-    /// - `sentinels`: A vector of connection information for the Sentinel nodes.
-    /// - `service_name`: The name of the Redis master service.
-    /// - `info`: `SentinelNodeConnectionInfo` to customize the connection to the Redis master.
-    pub fn with_node_connection_info(
-        sentinels: Vec<T>,
-        service_name: &str,
-        info: SentinelNodeConnectionInfo,
+    /// This allows specifying a custom `SentinelNodeConnectionInfo` and `SentinelServerType`
+    /// (e.g., Master or Slave).
+    pub fn with_client_info(
+        addrs: Vec<T>,
+        service_name: impl AsRef<str>,
+        node_conn_info: SentinelNodeConnectionInfo,
+        server_type: SentinelServerType,
     ) -> Self {
         Self {
-            pool: Some(RedisPool::Sentinel(
-                sentinels,
-                service_name.to_string(),
-                Some(info),
+            pool: Some(RedisPool::Client(
+                addrs,
+                service_name.as_ref().to_string(),
+                Some(node_conn_info),
+                server_type,
                 r2d2::Pool::builder(),
             )),
         }
     }
 
-    /// Creates a new `RedisSentinelDataSrc` instance with specific node connection information
-    /// and a custom `r2d2::Pool::builder`.
+    /// Creates a new `RedisSentinelDataSrc` instance with detailed client information and a
+    /// custom pool builder.
     ///
-    /// This provides fine-grained control over both the Redis master connection details
-    /// and the connection pool's configuration.
-    ///
-    /// - `sentinels`: A vector of connection information for the Sentinel nodes.
-    /// - `service_name`: The name of the Redis master service.
-    /// - `info`: `SentinelNodeConnectionInfo` to customize the connection to the Redis master.
-    /// - `builder`: A custom `r2d2::Pool::builder` to configure the connection pool.
-    pub fn with_node_connection_info_and_pool_builder(
-        sentinels: Vec<T>,
-        service_name: &str,
-        info: SentinelNodeConnectionInfo,
-        builder: r2d2::Builder<LockedSentinelClient>,
+    /// This allows for fine-tuning the connection pool settings.
+    pub fn with_client_info_and_pool_builder(
+        addrs: Vec<T>,
+        service_name: impl AsRef<str>,
+        node_conn_info: SentinelNodeConnectionInfo,
+        server_type: SentinelServerType,
+        pool_builder: r2d2::Builder<LockedSentinelClient>,
     ) -> Self {
         Self {
-            pool: Some(RedisPool::Sentinel(
-                sentinels,
-                service_name.to_string(),
-                Some(info),
-                builder,
+            pool: Some(RedisPool::Client(
+                addrs,
+                service_name.as_ref().to_string(),
+                Some(node_conn_info),
+                server_type,
+                pool_builder,
             )),
         }
     }
 }
 
 impl RedisSentinelDataSrc<&'static str> {
-    /// Creates a new `RedisSentinelDataSrc` instance using a pre-configured `SentinelClientBuilder`.
-    ///
-    /// This allows for advanced configuration of the `SentinelClient` before it is built.
-    ///
-    /// - `builder`: A `SentinelClientBuilder` instance.
-    pub fn with_sentinel_client_builder(builder: SentinelClientBuilder) -> Self {
+    /// Creates a new `RedisSentinelDataSrc` instance using an existing `SentinelClientBuilder`.
+    pub fn with_client_builder(client_builder: SentinelClientBuilder) -> Self {
         Self {
-            pool: Some(RedisPool::SentinelClient(builder, r2d2::Pool::builder())),
+            pool: Some(RedisPool::Builder(client_builder, r2d2::Pool::builder())),
         }
     }
 
-    /// Creates a new `RedisSentinelDataSrc` instance using a pre-configured `SentinelClientBuilder`
-    /// and a custom `r2d2::Pool::builder`.
-    ///
-    /// This provides the most flexible way to configure the Redis Sentinel data source,
-    /// allowing full control over both the `SentinelClient` and the connection pool.
-    ///
-    /// - `client_builder`: A `SentinelClientBuilder` instance.
-    /// - `pool_builder`: A custom `r2d2::Pool::builder` to configure the connection pool.
-    pub fn with_sentinel_client_and_pool_builder(
+    /// Creates a new `RedisSentinelDataSrc` instance using an existing `SentinelClientBuilder`
+    /// and a custom pool builder.
+    pub fn with_client_builder_and_pool_builder(
         client_builder: SentinelClientBuilder,
         pool_builder: r2d2::Builder<LockedSentinelClient>,
     ) -> Self {
         Self {
-            pool: Some(RedisPool::SentinelClient(client_builder, pool_builder)),
+            pool: Some(RedisPool::Builder(client_builder, pool_builder)),
         }
     }
 }
@@ -344,16 +336,21 @@ where
         let pool =
             pool_opt.ok_or_else(|| errs::Err::new(RedisSentinelDataSrcError::AlreadySetup))?;
         match pool {
-            RedisPool::Sentinel(sentinels, service_name, node_conn_info_opt, pool_builder) => {
-                let client = SentinelClient::build(
-                    sentinels,
-                    service_name,
-                    node_conn_info_opt,
-                    SentinelServerType::Master,
-                )
-                .map_err(|e| {
-                    errs::Err::with_source(RedisSentinelDataSrcError::FailToBuildSentinelClient, e)
-                })?;
+            RedisPool::Client(
+                addrs,
+                service_name,
+                node_conn_info_opt,
+                server_type,
+                pool_builder,
+            ) => {
+                let client =
+                    SentinelClient::build(addrs, service_name, node_conn_info_opt, server_type)
+                        .map_err(|e| {
+                            errs::Err::with_source(
+                                RedisSentinelDataSrcError::FailToBuildSentinelClient,
+                                e,
+                            )
+                        })?;
 
                 let pool = pool_builder
                     .build(LockedSentinelClient::new(client))
@@ -364,7 +361,7 @@ where
                 self.pool = Some(RedisPool::Object(pool));
                 Ok(())
             }
-            RedisPool::SentinelClient(client_builder, pool_builder) => {
+            RedisPool::Builder(client_builder, pool_builder) => {
                 let client = client_builder.build().map_err(|e| {
                     errs::Err::with_source(RedisSentinelDataSrcError::FailToBuildSentinelClient, e)
                 })?;
@@ -548,7 +545,7 @@ mod tests_of_sentinel_sync {
     }
 
     #[test]
-    fn ok_with_node_connection_info() -> errs::Result<()> {
+    fn ok_with_client_info() -> errs::Result<()> {
         let redis_connection_info = RedisConnectionInfo::default().set_db(1);
         let sentinel_node_connection_info =
             SentinelNodeConnectionInfo::default().set_redis_connection_info(redis_connection_info);
@@ -556,7 +553,7 @@ mod tests_of_sentinel_sync {
         let mut data = DataHub::new();
         data.uses(
             "redis",
-            RedisSentinelDataSrc::with_node_connection_info(
+            RedisSentinelDataSrc::with_client_info(
                 vec![
                     "redis://127.0.0.1:26479",
                     "redis://127.0.0.1:26480",
@@ -564,6 +561,7 @@ mod tests_of_sentinel_sync {
                 ],
                 "mymaster",
                 sentinel_node_connection_info,
+                SentinelServerType::Master,
             ),
         );
         data.run(sample_logic)?;
@@ -571,7 +569,7 @@ mod tests_of_sentinel_sync {
     }
 
     #[test]
-    fn ok_with_node_connection_info_and_pool_builder() -> errs::Result<()> {
+    fn ok_with_client_info_and_pool_builder() -> errs::Result<()> {
         let redis_connection_info = RedisConnectionInfo::default().set_db(1);
         let sentinel_node_connection_info =
             SentinelNodeConnectionInfo::default().set_redis_connection_info(redis_connection_info);
@@ -586,7 +584,7 @@ mod tests_of_sentinel_sync {
         let mut data = DataHub::new();
         data.uses(
             "redis",
-            RedisSentinelDataSrc::with_node_connection_info_and_pool_builder(
+            RedisSentinelDataSrc::with_client_info_and_pool_builder(
                 vec![
                     "redis://127.0.0.1:26479",
                     "redis://127.0.0.1:26480",
@@ -594,6 +592,7 @@ mod tests_of_sentinel_sync {
                 ],
                 "mymaster",
                 sentinel_node_connection_info,
+                SentinelServerType::Master,
                 pool_builder,
             ),
         );
@@ -602,7 +601,7 @@ mod tests_of_sentinel_sync {
     }
 
     #[test]
-    fn ok_with_sentinel_client_builder() -> errs::Result<()> {
+    fn ok_with_client_builder() -> errs::Result<()> {
         let builder = SentinelClientBuilder::new(
             vec![
                 redis::ConnectionAddr::Tcp(String::from("127.0.0.1"), 26479),
@@ -615,16 +614,13 @@ mod tests_of_sentinel_sync {
         .unwrap();
 
         let mut data = DataHub::new();
-        data.uses(
-            "redis",
-            RedisSentinelDataSrc::with_sentinel_client_builder(builder),
-        );
+        data.uses("redis", RedisSentinelDataSrc::with_client_builder(builder));
         data.run(sample_logic)?;
         Ok(())
     }
 
     #[test]
-    fn with_sentinel_client_and_pool_builder() -> errs::Result<()> {
+    fn ok_with_client_builder_and_pool_builder() -> errs::Result<()> {
         let builder = SentinelClientBuilder::new(
             vec![
                 redis::ConnectionAddr::Tcp(String::from("127.0.0.1"), 26479),
@@ -646,7 +642,7 @@ mod tests_of_sentinel_sync {
         let mut data = DataHub::new();
         data.uses(
             "redis",
-            RedisSentinelDataSrc::with_sentinel_client_and_pool_builder(builder, pool_builder),
+            RedisSentinelDataSrc::with_client_builder_and_pool_builder(builder, pool_builder),
         );
         data.run(sample_logic)?;
         Ok(())

--- a/src/standalone_async.rs
+++ b/src/standalone_async.rs
@@ -6,7 +6,7 @@ use deadpool_redis::{Config, Connection, Pool, PoolConfig, Runtime};
 use sabi::tokio::{AsyncGroup, DataConn, DataSrc};
 
 use std::future::Future;
-use std::{fmt, mem, pin};
+use std::{mem, pin};
 
 /// Errors that can occur when using `RedisAsyncDataSrc` or `RedisAsyncDataConn`.
 #[derive(Debug)]
@@ -17,10 +17,6 @@ pub enum RedisAsyncDataSrcError {
     /// Indicates that an attempt was made to set up `RedisAsyncDataSrc` when it was already set up,
     /// or to set the internal pool when it was already set.
     AlreadySetup,
-
-    /// Indicates a failure to convert the `redis::ConnectionInfo` into
-    /// `deadpool_redis::ConnectionInfo`.
-    FailToConvertConnectionInfo,
 
     /// Indicates a failure to build the Redis connection pool.
     FailToBuildPool,
@@ -237,67 +233,59 @@ impl DataConn for RedisAsyncDataConn {
     }
 }
 
-/// `RedisAsyncDataSrc` serves as an asynchronous data source for Redis, implementing the `DataSrc` trait
-/// from the `sabi::tokio` library. It manages the creation and lifecycle of a `deadpool_redis` connection pool.
+/// Manages an asynchronous connection pool for a Redis data source.
 ///
-/// `T` is a type that can be converted into `redis::ConnectionInfo`.
-pub struct RedisAsyncDataSrc<T>
-where
-    T: redis::IntoConnectionInfo + Sized + fmt::Debug,
-{
-    pool: Option<RedisPool<T>>,
+/// This struct is responsible for setting up the Redis connection pool
+/// using `deadpool_redis` and creating new `RedisAsyncDataConn` instances from the pool.
+///
+/// `RedisAsyncDataSrc` implements the `DataSrc` trait from `sabi::tokio`, allowing it to be used
+/// within an asynchronous `DataHub`.
+pub struct RedisAsyncDataSrc {
+    pool: Option<RedisPool>,
 }
 
-enum RedisPool<T>
-where
-    T: redis::IntoConnectionInfo + Sized + fmt::Debug,
-{
+enum RedisPool {
     Object(Pool),
-    Config(T, PoolConfig),
+    Config(Config),
 }
 
-impl<T> RedisAsyncDataSrc<T>
-where
-    T: redis::IntoConnectionInfo + Sized + fmt::Debug,
-{
-    /// Creates a new `RedisAsyncDataSrc` with the specified connection information and default
-    /// pool configuration.
+impl RedisAsyncDataSrc {
+    /// Creates a new `RedisAsyncDataSrc` instance with the specified Redis address.
     ///
-    /// The actual connection pool is built during the `setup_async` call.
-    ///
-    /// # Arguments
-    /// - `conn_info`: Connection information for the Redis server (e.g., a URL string or `redis::ConnectionInfo`).
-    ///
-    /// # Returns
-    /// A new `RedisAsyncDataSrc` instance.
-    pub fn new(conn_info: T) -> Self {
+    /// The `addr` parameter can be a connection string (e.g., "redis://127.0.0.1:6379/0").
+    pub fn new(addr: impl AsRef<str>) -> Self {
         Self {
-            pool: Some(RedisPool::Config(conn_info, PoolConfig::default())),
+            pool: Some(RedisPool::Config(Config {
+                url: Some(addr.as_ref().to_string()),
+                connection: None,
+                pool: Some(PoolConfig::default()),
+            })),
         }
     }
 
-    /// Creates a new `RedisAsyncDataSrc` with the specified connection information and a custom
+    /// Creates a new `RedisAsyncDataSrc` instance with the specified Redis address and a custom
     /// pool configuration.
     ///
-    /// The actual connection pool is built during the `setup_async` call.
-    ///
-    /// # Arguments
-    /// - `conn_info`: Connection information for the Redis server (e.g., a URL string or `redis::ConnectionInfo`).
-    /// - `pool_config`: Custom configuration for the `deadpool_redis` connection pool.
-    ///
-    /// # Returns
-    /// A new `RedisAsyncDataSrc` instance.
-    pub fn with_pool_config(conn_info: T, pool_config: PoolConfig) -> Self {
+    /// This allows for fine-tuning the connection pool settings, such as max size and timeouts.
+    pub fn with_addr_and_pool_config(addr: impl AsRef<str>, pool_config: PoolConfig) -> Self {
         Self {
-            pool: Some(RedisPool::Config(conn_info, pool_config)),
+            pool: Some(RedisPool::Config(Config {
+                url: Some(addr.as_ref().to_string()),
+                connection: None,
+                pool: Some(pool_config),
+            })),
+        }
+    }
+
+    /// Creates a new `RedisAsyncDataSrc` instance using an existing `deadpool_redis::Config`.
+    pub fn with_config(cfg: Config) -> Self {
+        Self {
+            pool: Some(RedisPool::Config(cfg)),
         }
     }
 }
 
-impl<T> DataSrc<RedisAsyncDataConn> for RedisAsyncDataSrc<T>
-where
-    T: redis::IntoConnectionInfo + Sized + Send + fmt::Debug,
-{
+impl DataSrc<RedisAsyncDataConn> for RedisAsyncDataSrc {
     /// Asynchronously sets up the Redis connection pool.
     /// This method should be called once before attempting to create any `RedisAsyncDataConn` instances.
     ///
@@ -312,12 +300,7 @@ where
         let pool_opt = mem::take(&mut self.pool);
         let pool = pool_opt.ok_or_else(|| errs::Err::new(RedisAsyncDataSrcError::AlreadySetup))?;
         match pool {
-            RedisPool::Config(conn_info, pool_config) => {
-                let ci = conn_info.into_connection_info().map_err(|e| {
-                    errs::Err::with_source(RedisAsyncDataSrcError::FailToConvertConnectionInfo, e)
-                })?;
-                let mut cfg = Config::from_connection_info(ci);
-                cfg.pool.replace(pool_config);
+            RedisPool::Config(cfg) => {
                 let pool = cfg.create_pool(Some(Runtime::Tokio1)).map_err(|e| {
                     errs::Err::with_source(RedisAsyncDataSrcError::FailToBuildPool, e)
                 })?;
@@ -538,17 +521,15 @@ mod tests_of_standalone_async {
 
     #[tokio::test]
     async fn ok_by_connection_info() -> errs::Result<()> {
-        let ci: redis::ConnectionInfo = "redis://127.0.0.1:6379/1".parse().unwrap();
-
         let mut data = DataHub::new();
-        data.uses("redis", RedisAsyncDataSrc::new(ci));
+        data.uses("redis", RedisAsyncDataSrc::new("redis://127.0.0.1:6379/1"));
         data.run_async(logic!(sample_logic_async)).await?;
         Ok(())
     }
 
     #[tokio::test]
     async fn ok_by_uri_and_pool_config() -> errs::Result<()> {
-        let ci: redis::ConnectionInfo = "redis://127.0.0.1:6379/1".parse().unwrap();
+        let url = "redis://127.0.0.1:6379/1".to_string();
         let pc = PoolConfig {
             max_size: 10,
             timeouts: Timeouts {
@@ -560,7 +541,10 @@ mod tests_of_standalone_async {
         };
 
         let mut data = DataHub::new();
-        data.uses("redis", RedisAsyncDataSrc::with_pool_config(ci, pc));
+        data.uses(
+            "redis",
+            RedisAsyncDataSrc::with_addr_and_pool_config(url, pc),
+        );
         data.run_async(logic!(sample_logic_async)).await?;
         Ok(())
     }
@@ -578,7 +562,7 @@ mod tests_of_standalone_async {
                         assert_eq!(errors[0].0.as_ref(), "redis");
                         if let Ok(r) = errors[0].1.reason::<RedisAsyncDataSrcError>() {
                             match r {
-                                RedisAsyncDataSrcError::FailToConvertConnectionInfo => {}
+                                RedisAsyncDataSrcError::FailToBuildPool => {}
                                 _ => panic!(),
                             }
                         } else {
@@ -588,14 +572,22 @@ mod tests_of_standalone_async {
                             .1
                             .source()
                             .unwrap()
-                            .downcast_ref::<redis::RedisError>()
+                            .downcast_ref::<deadpool_redis::CreatePoolError>()
                             .unwrap();
-                        assert_eq!(e.kind(), redis::ErrorKind::InvalidClientConfig);
-                        assert!(e.detail().is_none());
-                        assert!(e.code().is_none());
-                        assert_eq!(e.category(), "invalid client config");
+                        match e {
+                            deadpool_redis::CreatePoolError::Config(ce) => match ce {
+                                deadpool_redis::ConfigError::Redis(re) => {
+                                    assert_eq!(re.kind(), redis::ErrorKind::InvalidClientConfig);
+                                    assert_eq!(re.detail(), None);
+                                    assert_eq!(re.code(), None);
+                                    assert_eq!(re.category(), "invalid client config");
+                                }
+                                _ => panic!(),
+                            },
+                            _ => panic!("{e:?}"),
+                        }
                     }
-                    _ => panic!("{:?}", err),
+                    _ => panic!("{err:?}"),
                 }
             } else {
                 panic!();

--- a/src/standalone_sync.rs
+++ b/src/standalone_sync.rs
@@ -376,23 +376,23 @@ impl<T> RedisDataSrc<T>
 where
     T: redis::IntoConnectionInfo + Sized + Debug,
 {
-    /// Creates a new `RedisDataSrc` instance.
+    /// Creates a new `RedisDataSrc` instance with the specified Redis address.
     ///
-    /// The connection information is stored, but the connection pool is not built
-    /// until the `setup` method is called.
-    pub fn new(conn_info: T) -> Self {
+    /// The `addr` parameter can be a connection string (e.g., "redis://127.0.0.1:6379/0")
+    /// or any type that implements `redis::IntoConnectionInfo`.
+    pub fn new(addr: T) -> Self {
         Self {
-            pool: Some(RedisPool::Config(conn_info, r2d2::Pool::builder())),
+            pool: Some(RedisPool::Config(addr, r2d2::Pool::builder())),
         }
     }
 
-    /// Creates a new `RedisDataSrc` instance with connection pooling configurations.
+    /// Creates a new `RedisDataSrc` instance with the specified Redis address and a custom pool
+    /// builder.
     ///
-    /// The connection information is stored, but the connection pool is not built
-    /// until the `setup` method is called.
-    pub fn with_pool_builder(conn_info: T, pool_builder: r2d2::Builder<redis::Client>) -> Self {
+    /// This allows for fine-tuning the connection pool settings, such as max size, idle timeout, etc.
+    pub fn with_addr_and_pool_builder(addr: T, pool_builder: r2d2::Builder<redis::Client>) -> Self {
         Self {
-            pool: Some(RedisPool::Config(conn_info, pool_builder)),
+            pool: Some(RedisPool::Config(addr, pool_builder)),
         }
     }
 }
@@ -410,8 +410,8 @@ where
         let pool_opt = mem::take(&mut self.pool);
         let pool = pool_opt.ok_or_else(|| errs::Err::new(RedisDataSrcError::AlreadySetup))?;
         match pool {
-            RedisPool::Config(conn_info, pool_builder) => {
-                let client = redis::Client::open(conn_info)
+            RedisPool::Config(addr, pool_builder) => {
+                let client = redis::Client::open(addr)
                     .map_err(|e| errs::Err::with_source(RedisDataSrcError::FailToOpenClient, e))?;
 
                 let pool = pool_builder
@@ -604,7 +604,7 @@ mod tests_of_standalone_sync {
         let mut data = DataHub::new();
         data.uses(
             "redis",
-            RedisDataSrc::with_pool_builder("redis://127.0.0.1:6379/2", builder),
+            RedisDataSrc::with_addr_and_pool_builder("redis://127.0.0.1:6379/2", builder),
         );
         data.run(sample_logic)?;
         Ok(())


### PR DESCRIPTION
This PR includes the following changes:
- Updated field names for `RedisPool` across all `DataSrc` implementations.
- Stopped forcing the use of `IntoConnectionInfo` in `~AsyncDataSrc` modules.
- Updated `~AsyncDataSrc` to use the specific `Config` provided by each `deadpool_redis` configuration module.