### PR TITLE
new: added supports for pubsub messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { version = "1", optional = true }
 [dev-dependencies]
 override_macro = "0.1"
 inventory = "0.3"
+futures = "0.3"
 
 [features]
 default = ["standalone-sync"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 //! - **Standalone**: For a single Redis server.
 //! - **Sentinel**: For a Redis Sentinel managed setup, providing automatic failover.
 //! - **Cluster**: For a distributed Redis Cluster setup.
+//! - **Pub/Sub**: For processing Redis Pub/Sub messages within the `sabi` framework.
 //!
 //! Each configuration has both **synchronous** and **asynchronous** (compatible with `tokio`)
 //! implementations, which can be enabled via features.
@@ -47,6 +48,20 @@ mod cluster_sync;
 
 #[cfg(feature = "cluster-async")]
 mod cluster_async;
+
+#[cfg(any(
+    feature = "standalone-sync",
+    feature = "sentinel-sync",
+    feature = "cluster-sync"
+))]
+mod pubsub_sync;
+
+#[cfg(any(
+    feature = "standalone-async",
+    feature = "sentinel-async",
+    feature = "cluster-async"
+))]
+mod pubsub_async;
 
 #[cfg(feature = "standalone-sync")]
 #[cfg_attr(docsrs, doc(cfg(feature = "standalone-sync")))]
@@ -103,4 +118,47 @@ pub mod cluster {
     pub use crate::cluster_async::{
         RedisClusterAsyncDataConn, RedisClusterAsyncDataSrc, RedisClusterAsyncError,
     };
+}
+
+/// This module provides components for processing Redis Pub/Sub messages.
+///
+/// - **Synchronous**: For synchronous processing, it provides components that handle messages
+///   in a blocking manner.
+/// - **Asynchronous**: For asynchronous processing, it provides components that work with
+///   `tokio` and `redis-rs` async Pub/Sub features.
+///
+/// This module allows received messages to be treated as `sabi` data connections. By wrapping
+/// a message in a data connection, it can be passed through the `sabi` data access layer,
+/// making it easy to integrate message handling into your business logic consistently
+/// across Standalone, Sentinel, and Cluster modes.
+pub mod pubsub {
+    #[cfg(any(
+        feature = "standalone-sync",
+        feature = "sentinel-sync",
+        feature = "cluster-sync"
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "standalone-sync",
+            feature = "sentinel-sync",
+            feature = "cluster-sync"
+        )))
+    )]
+    pub use crate::pubsub_sync::{RedisPubSubDataConn, RedisPubSubDataSrc};
+
+    #[cfg(any(
+        feature = "standalone-async",
+        feature = "sentinel-async",
+        feature = "cluster-async"
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "standalone-async",
+            feature = "sentinel-async",
+            feature = "cluster-async"
+        )))
+    )]
+    pub use crate::pubsub_async::{RedisPubSubAsyncDataConn, RedisPubSubAsyncDataSrc};
 }

--- a/src/pubsub_async/mod.rs
+++ b/src/pubsub_async/mod.rs
@@ -1,0 +1,165 @@
+// Copyright (C) 2026 Takayuki Sato. All Rights Reserved.
+// This program is free software under MIT License.
+// See the file LICENSE in this distribution for more details.
+
+use redis::Msg;
+use sabi::tokio::{AsyncGroup, DataConn, DataSrc};
+use std::sync::Arc;
+
+/// A data connection that carries a Redis Pub/Sub message for async operations.
+///
+/// This structure allows a received Pub/Sub message to be passed through the `sabi` data access
+/// layer in an asynchronous context. It implements `DataConn`, enabling it to be retrieved by a
+/// data access object.
+pub struct RedisPubSubAsyncDataConn {
+    msg: Arc<Msg>,
+}
+
+impl RedisPubSubAsyncDataConn {
+    fn new(msg: Arc<Msg>) -> Self {
+        Self { msg }
+    }
+
+    /// Returns a reference to the contained Redis Pub/Sub message.
+    pub fn get_message(&self) -> &Msg {
+        &self.msg
+    }
+}
+
+impl DataConn for RedisPubSubAsyncDataConn {
+    async fn commit_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
+        Ok(())
+    }
+    async fn rollback_async(&mut self, _ag: &mut AsyncGroup) {}
+    fn close(&mut self) {}
+}
+
+/// A data source that wraps a Redis Pub/Sub message for async operations.
+///
+/// This structure is used to register a single received message into the `sabi` framework
+/// so that it can be accessed via `RedisPubSubAsyncDataConn` during an async data operation.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use sabi_redis::pubsub_async::{RedisPubSubAsyncDataSrc, RedisPubSubAsyncDataConn};
+/// use sabi::tokio::DataHub;
+/// use futures::StreamExt;
+///
+/// # async fn example() {
+/// // Assume `msg` is a `redis::Msg` received from an async subscriber.
+/// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+/// # let (mut sink, mut stream) = client.get_async_pubsub().await.unwrap().split();
+/// # sink.subscribe("channel").await.unwrap();
+/// # let msg = stream.next().await.unwrap();
+///
+/// let mut data = DataHub::new();
+/// data.uses("redis/pubsub", RedisPubSubAsyncDataSrc::new(msg));
+///
+/// data.run_async(|acc: &mut DataHub| async move {
+///     let conn = acc.get_data_conn_async::<RedisPubSubAsyncDataConn>("redis/pubsub").await?;
+///     let message = conn.get_message();
+///     // Process the message...
+///     Ok(())
+/// }).await.unwrap();
+/// # }
+/// ```
+pub struct RedisPubSubAsyncDataSrc {
+    msg: Arc<Msg>,
+}
+
+impl RedisPubSubAsyncDataSrc {
+    /// Creates a new `RedisPubSubAsyncDataSrc` with the given Redis message.
+    pub fn new(msg: Msg) -> Self {
+        Self { msg: Arc::new(msg) }
+    }
+}
+
+impl DataSrc<RedisPubSubAsyncDataConn> for RedisPubSubAsyncDataSrc {
+    async fn setup_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
+        Ok(())
+    }
+
+    fn close(&mut self) {}
+
+    async fn create_data_conn_async(&mut self) -> errs::Result<Box<RedisPubSubAsyncDataConn>> {
+        let msg = Arc::clone(&self.msg);
+        Ok(Box::new(RedisPubSubAsyncDataConn::new(msg)))
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use deadpool_redis::{Config, Runtime};
+    use futures::StreamExt;
+    use override_macro::{overridable, override_with};
+    use redis::AsyncTypedCommands;
+    use sabi::tokio::{logic, DataAcc, DataHub};
+    use tokio::time;
+
+    async fn sample_logic(data: &mut impl SampleAsyncData1) -> errs::Result<()> {
+        match data.greet_async().await.unwrap().as_ref() {
+            "Hello" => Ok(()),
+            s => panic!("{}", s),
+        }
+    }
+
+    #[overridable]
+    trait SampleAsyncDataAcc1: DataAcc {
+        async fn greet_async(&mut self) -> errs::Result<String> {
+            let data_conn = self
+                .get_data_conn_async::<RedisPubSubAsyncDataConn>("redis/pubsub")
+                .await?;
+            let msg = data_conn.get_message();
+            let payload: String = msg.get_payload().unwrap();
+            Ok(payload)
+        }
+    }
+    impl SampleAsyncDataAcc1 for DataHub {}
+
+    #[overridable]
+    trait SampleAsyncData1 {
+        async fn greet_async(&mut self) -> errs::Result<String>;
+    }
+    #[override_with(SampleAsyncDataAcc1)]
+    impl SampleAsyncData1 for DataHub {}
+
+    #[tokio::test]
+    async fn test() {
+        // client/publish
+        let handle = {
+            let cfg = Config::from_url("redis://127.0.0.1/");
+            let pool = cfg.create_pool(Some(Runtime::Tokio1)).unwrap();
+
+            let handle = tokio::spawn(async move {
+                let mut conn = pool.get().await.unwrap();
+                time::sleep(time::Duration::from_millis(100)).await;
+                conn.publish("channel_1", "Hello".to_string())
+                    .await
+                    .unwrap();
+            });
+
+            handle
+        };
+
+        // server/subscribe
+        {
+            let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+            let (mut sink, mut stream) = client.get_async_pubsub().await.unwrap().split();
+            sink.subscribe("channel_1").await.unwrap();
+
+            loop {
+                let msg = stream.next().await.unwrap();
+
+                let mut data = DataHub::new();
+                data.uses("redis/pubsub", RedisPubSubAsyncDataSrc::new(msg));
+                if data.run_async(logic!(sample_logic)).await.is_ok() {
+                    break;
+                }
+            }
+        }
+
+        handle.await.unwrap();
+    }
+}

--- a/src/pubsub_sync/mod.rs
+++ b/src/pubsub_sync/mod.rs
@@ -1,0 +1,157 @@
+// Copyright (C) 2026 Takayuki Sato. All Rights Reserved.
+// This program is free software under MIT License.
+// See the file LICENSE in this distribution for more details.
+
+use redis::Msg;
+use sabi::{AsyncGroup, DataConn, DataSrc};
+use std::sync::Arc;
+
+/// A data connection that carries a Redis Pub/Sub message.
+///
+/// This structure allows a received Pub/Sub message to be passed through the `sabi` data access
+/// layer. It implements `DataConn`, enabling it to be retrieved by a data access object.
+pub struct RedisPubSubDataConn {
+    msg: Arc<Msg>,
+}
+
+impl RedisPubSubDataConn {
+    fn new(msg: Arc<Msg>) -> Self {
+        Self { msg }
+    }
+
+    /// Returns a reference to the contained Redis Pub/Sub message.
+    pub fn get_message(&self) -> &Msg {
+        &self.msg
+    }
+}
+
+impl DataConn for RedisPubSubDataConn {
+    fn commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
+        Ok(())
+    }
+    fn rollback(&mut self, _ag: &mut AsyncGroup) {}
+    fn close(&mut self) {}
+}
+
+/// A data source that wraps a Redis Pub/Sub message.
+///
+/// This structure is used to register a single received message into the `sabi` framework
+/// so that it can be accessed via `RedisPubSubDataConn` during a data operation.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use sabi_redis::pubsub::{RedisPubSubDataSrc, RedisPubSubDataConn};
+/// use sabi::DataHub;
+///
+/// // Assume `msg` is a `redis::Msg` received from a subscriber.
+/// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+/// # let mut con = client.get_connection().unwrap();
+/// # let mut pubsub = con.as_pubsub();
+/// # pubsub.subscribe(&["channel"]).unwrap();
+/// # let msg = pubsub.get_message().unwrap();
+///
+/// let mut data = DataHub::new();
+/// data.uses("redis/pubsub", RedisPubSubDataSrc::new(msg));
+///
+/// data.run(|acc: &mut DataHub| {
+///     let conn = acc.get_data_conn::<RedisPubSubDataConn>("redis/pubsub")?;
+///     let message = conn.get_message();
+///     // Process the message...
+///     Ok(())
+/// }).unwrap();
+/// ```
+pub struct RedisPubSubDataSrc {
+    msg: Arc<Msg>,
+}
+
+impl RedisPubSubDataSrc {
+    /// Creates a new `RedisPubSubDataSrc` with the given Redis message.
+    pub fn new(msg: Msg) -> Self {
+        Self { msg: Arc::new(msg) }
+    }
+}
+
+impl DataSrc<RedisPubSubDataConn> for RedisPubSubDataSrc {
+    fn setup(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
+        Ok(())
+    }
+
+    fn close(&mut self) {}
+
+    fn create_data_conn(&mut self) -> errs::Result<Box<RedisPubSubDataConn>> {
+        let msg = Arc::clone(&self.msg);
+        Ok(Box::new(RedisPubSubDataConn::new(msg)))
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use override_macro::{overridable, override_with};
+    use r2d2::Pool;
+    use redis::TypedCommands;
+    use std::{thread, time};
+
+    fn sample_logic(data: &mut impl SampleData1) -> errs::Result<()> {
+        match data.greet()?.as_ref() {
+            "Hello" => Ok(()),
+            s => panic!("{}", s),
+        }
+    }
+
+    #[overridable]
+    trait SampleDataAcc1: sabi::DataAcc {
+        fn greet(&mut self) -> errs::Result<String> {
+            let data_conn = self.get_data_conn::<RedisPubSubDataConn>("redis/pubsub")?;
+            let msg = data_conn.get_message();
+            let payload: String = msg.get_payload().unwrap();
+            Ok(payload)
+        }
+    }
+    impl SampleDataAcc1 for sabi::DataHub {}
+
+    #[overridable]
+    trait SampleData1 {
+        fn greet(&mut self) -> errs::Result<String>;
+    }
+    #[override_with(SampleDataAcc1)]
+    impl SampleData1 for sabi::DataHub {}
+
+    #[test]
+    fn test() {
+        // client/publish
+        let handle = {
+            let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+            let pool = Pool::builder().build(client).unwrap();
+
+            let handle = thread::spawn(move || {
+                let mut conn = pool.get().unwrap();
+                thread::sleep(time::Duration::from_millis(100));
+                conn.publish("channel_1", "Hello".to_string()).unwrap();
+            });
+
+            handle
+        };
+
+        // server/subscribe
+        {
+            let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+            let mut con = client.get_connection().unwrap();
+            let mut pubsub = con.as_pubsub();
+            pubsub.subscribe(&["channel_1", "channel_2"]).unwrap();
+
+            loop {
+                let msg = pubsub.get_message().unwrap();
+
+                let mut data = sabi::DataHub::new();
+                data.uses("redis/pubsub", RedisPubSubDataSrc::new(msg));
+                if data.run(sample_logic).is_ok() {
+                    break;
+                }
+            }
+        }
+
+        handle.join().unwrap();
+    }
+}


### PR DESCRIPTION
This PR adds sync. and async. DataSrcs and DataConns for Redis PubSub message.
After receiving the Redis PubSub subscription message, it is passed to DataAcc via DataSrc -> DataConn so that it can be processed.

This PR resolves partly #58.