### PR TITLE
refactor: changed how each DataSrc holds its setup config

### DIFF
--- a/src/cluster_sync.rs
+++ b/src/cluster_sync.rs
@@ -217,7 +217,7 @@ pub struct RedisClusterDataSrc {
 
 enum RedisPool {
     Object(Pool<ClusterClient>),
-    Builder(Box<ClusterClientBuilder>, Builder<ClusterClient>),
+    Builder(Box<(ClusterClientBuilder, Builder<ClusterClient>)>),
 }
 
 impl RedisClusterDataSrc {
@@ -235,7 +235,7 @@ impl RedisClusterDataSrc {
     {
         let builder = ClusterClientBuilder::new(addrs);
         Self {
-            pool: Some(RedisPool::Builder(Box::new(builder), Pool::builder())),
+            pool: Some(RedisPool::Builder(Box::new((builder, Pool::builder())))),
         }
     }
 
@@ -248,10 +248,10 @@ impl RedisClusterDataSrc {
     /// Returns a new instance of `RedisClusterDataSrc`.
     pub fn with_client_builder(client_builder: ClusterClientBuilder) -> Self {
         Self {
-            pool: Some(RedisPool::Builder(
-                Box::new(client_builder),
+            pool: Some(RedisPool::Builder(Box::new((
+                client_builder,
                 Pool::builder(),
-            )),
+            )))),
         }
     }
 
@@ -268,7 +268,7 @@ impl RedisClusterDataSrc {
         pool_builder: Builder<ClusterClient>,
     ) -> Self {
         Self {
-            pool: Some(RedisPool::Builder(Box::new(client_builder), pool_builder)),
+            pool: Some(RedisPool::Builder(Box::new((client_builder, pool_builder)))),
         }
     }
 }
@@ -278,7 +278,8 @@ impl DataSrc<RedisClusterDataConn> for RedisClusterDataSrc {
         let pool_opt = mem::take(&mut self.pool);
         let pool = pool_opt.ok_or_else(|| errs::Err::new(RedisClusterSyncError::AlreadySetup))?;
         match pool {
-            RedisPool::Builder(conn_builder, pool_builder) => {
+            RedisPool::Builder(cfg) => {
+                let (conn_builder, pool_builder) = *cfg;
                 let client = conn_builder.build().map_err(|e| {
                     errs::Err::with_source(RedisClusterSyncError::FailToBuildClient, e)
                 })?;

--- a/src/sentinel_sync.rs
+++ b/src/sentinel_sync.rs
@@ -230,22 +230,26 @@ where
     pool: Option<RedisPool<T>>,
 }
 
+struct SentinelConfig<T> {
+    addrs: Vec<T>,
+    service_name: String,
+    node_conn_info: Option<SentinelNodeConnectionInfo>,
+    server_type: SentinelServerType,
+    pool_builder: Builder<LockedSentinelClient>,
+}
+
+struct SentinelBuilderConfig {
+    client_builder: SentinelClientBuilder,
+    pool_builder: Builder<LockedSentinelClient>,
+}
+
 enum RedisPool<T>
 where
     T: IntoConnectionInfo,
 {
     Object(Pool<LockedSentinelClient>),
-    Client(
-        #[allow(clippy::type_complexity)]
-        Box<(
-            Vec<T>,
-            String,
-            Option<SentinelNodeConnectionInfo>,
-            SentinelServerType,
-            Builder<LockedSentinelClient>,
-        )>,
-    ),
-    Builder(Box<(SentinelClientBuilder, Builder<LockedSentinelClient>)>),
+    Client(Box<SentinelConfig<T>>),
+    Builder(Box<SentinelBuilderConfig>),
 }
 
 impl<T> RedisSentinelDataSrc<T>
@@ -262,13 +266,13 @@ where
     /// Returns a new instance of `RedisSentinelDataSrc`.
     pub fn new(addrs: Vec<T>, service_name: impl AsRef<str>) -> Self {
         Self {
-            pool: Some(RedisPool::Client(Box::new((
+            pool: Some(RedisPool::Client(Box::new(SentinelConfig {
                 addrs,
-                service_name.as_ref().to_string(),
-                None,
-                SentinelServerType::Master,
-                Pool::builder(),
-            )))),
+                service_name: service_name.as_ref().to_string(),
+                node_conn_info: None,
+                server_type: SentinelServerType::Master,
+                pool_builder: Pool::builder(),
+            }))),
         }
     }
 
@@ -289,13 +293,13 @@ where
         server_type: SentinelServerType,
     ) -> Self {
         Self {
-            pool: Some(RedisPool::Client(Box::new((
+            pool: Some(RedisPool::Client(Box::new(SentinelConfig {
                 addrs,
-                service_name.as_ref().to_string(),
-                Some(node_conn_info),
+                service_name: service_name.as_ref().to_string(),
+                node_conn_info: Some(node_conn_info),
                 server_type,
-                Pool::builder(),
-            )))),
+                pool_builder: Pool::builder(),
+            }))),
         }
     }
 
@@ -318,13 +322,13 @@ where
         pool_builder: Builder<LockedSentinelClient>,
     ) -> Self {
         Self {
-            pool: Some(RedisPool::Client(Box::new((
+            pool: Some(RedisPool::Client(Box::new(SentinelConfig {
                 addrs,
-                service_name.as_ref().to_string(),
-                Some(node_conn_info),
+                service_name: service_name.as_ref().to_string(),
+                node_conn_info: Some(node_conn_info),
                 server_type,
                 pool_builder,
-            )))),
+            }))),
         }
     }
 }
@@ -339,10 +343,10 @@ impl RedisSentinelDataSrc<&'static str> {
     /// Returns a new instance of `RedisSentinelDataSrc`.
     pub fn with_client_builder(client_builder: SentinelClientBuilder) -> Self {
         Self {
-            pool: Some(RedisPool::Builder(Box::new((
+            pool: Some(RedisPool::Builder(Box::new(SentinelBuilderConfig {
                 client_builder,
-                Pool::builder(),
-            )))),
+                pool_builder: Pool::builder(),
+            }))),
         }
     }
 
@@ -359,7 +363,10 @@ impl RedisSentinelDataSrc<&'static str> {
         pool_builder: Builder<LockedSentinelClient>,
     ) -> Self {
         Self {
-            pool: Some(RedisPool::Builder(Box::new((client_builder, pool_builder)))),
+            pool: Some(RedisPool::Builder(Box::new(SentinelBuilderConfig {
+                client_builder,
+                pool_builder,
+            }))),
         }
     }
 }
@@ -372,18 +379,19 @@ where
         let pool_opt = mem::take(&mut self.pool);
         let pool = pool_opt.ok_or_else(|| errs::Err::new(RedisSentinelSyncError::AlreadySetup))?;
         match pool {
-            RedisPool::Client(info) => {
-                let (addrs, service_name, node_conn_info, server_type, pool_builder) = *info;
-                let client =
-                    SentinelClient::build(addrs, service_name, node_conn_info, server_type)
-                        .map_err(|e| {
-                            errs::Err::with_source(
-                                RedisSentinelSyncError::FailToBuildSentinelClient,
-                                e,
-                            )
-                        })?;
+            RedisPool::Client(cfg) => {
+                let client = SentinelClient::build(
+                    cfg.addrs,
+                    cfg.service_name,
+                    cfg.node_conn_info,
+                    cfg.server_type,
+                )
+                .map_err(|e| {
+                    errs::Err::with_source(RedisSentinelSyncError::FailToBuildSentinelClient, e)
+                })?;
 
-                let pool = pool_builder
+                let pool = cfg
+                    .pool_builder
                     .build(LockedSentinelClient::new(client))
                     .map_err(|e| {
                         errs::Err::with_source(RedisSentinelSyncError::FailToBuildPool, e)
@@ -392,13 +400,13 @@ where
                 self.pool = Some(RedisPool::Object(pool));
                 Ok(())
             }
-            RedisPool::Builder(builder) => {
-                let (client_builder, pool_builder) = *builder;
-                let client = client_builder.build().map_err(|e| {
+            RedisPool::Builder(cfg) => {
+                let client = cfg.client_builder.build().map_err(|e| {
                     errs::Err::with_source(RedisSentinelSyncError::FailToBuildSentinelClient, e)
                 })?;
 
-                let pool = pool_builder
+                let pool = cfg
+                    .pool_builder
                     .build(LockedSentinelClient::new(client))
                     .map_err(|e| {
                         errs::Err::with_source(RedisSentinelSyncError::FailToBuildPool, e)

--- a/src/standalone_async.rs
+++ b/src/standalone_async.rs
@@ -228,7 +228,7 @@ pub struct RedisAsyncDataSrc {
 
 enum RedisPool {
     Object(Pool),
-    Config(Box<Config>),
+    Config(Config),
 }
 
 impl RedisAsyncDataSrc {
@@ -241,11 +241,11 @@ impl RedisAsyncDataSrc {
     /// Returns a new instance of `RedisAsyncDataSrc`.
     pub fn new(addr: impl AsRef<str>) -> Self {
         Self {
-            pool: Some(RedisPool::Config(Box::new(Config {
+            pool: Some(RedisPool::Config(Config {
                 url: Some(addr.as_ref().to_string()),
                 connection: None,
                 pool: Some(PoolConfig::default()),
-            }))),
+            })),
         }
     }
 
@@ -259,11 +259,11 @@ impl RedisAsyncDataSrc {
     /// Returns a new instance of `RedisAsyncDataSrc`.
     pub fn with_pool_config(addr: impl AsRef<str>, pool_config: PoolConfig) -> Self {
         Self {
-            pool: Some(RedisPool::Config(Box::new(Config {
+            pool: Some(RedisPool::Config(Config {
                 url: Some(addr.as_ref().to_string()),
                 connection: None,
                 pool: Some(pool_config),
-            }))),
+            })),
         }
     }
 
@@ -276,7 +276,7 @@ impl RedisAsyncDataSrc {
     /// Returns a new instance of `RedisAsyncDataSrc`.
     pub fn with_config(cfg: Config) -> Self {
         Self {
-            pool: Some(RedisPool::Config(Box::new(cfg))),
+            pool: Some(RedisPool::Config(cfg)),
         }
     }
 }

--- a/src/standalone_sync.rs
+++ b/src/standalone_sync.rs
@@ -217,7 +217,7 @@ where
     T: IntoConnectionInfo + Sized + Debug,
 {
     Object(Pool<Client>),
-    Config(Box<(T, Builder<Client>)>),
+    Config(T, Builder<Client>),
 }
 
 impl<T> RedisDataSrc<T>
@@ -233,7 +233,7 @@ where
     /// Returns a new instance of `RedisDataSrc`.
     pub fn new(addr: T) -> Self {
         Self {
-            pool: Some(RedisPool::Config(Box::new((addr, Pool::builder())))),
+            pool: Some(RedisPool::Config(addr, Pool::builder())),
         }
     }
 
@@ -247,7 +247,7 @@ where
     /// Returns a new instance of `RedisDataSrc`.
     pub fn with_pool_builder(addr: T, pool_builder: Builder<Client>) -> Self {
         Self {
-            pool: Some(RedisPool::Config(Box::new((addr, pool_builder)))),
+            pool: Some(RedisPool::Config(addr, pool_builder)),
         }
     }
 }
@@ -260,9 +260,7 @@ where
         let pool_opt = mem::take(&mut self.pool);
         let pool = pool_opt.ok_or_else(|| errs::Err::new(RedisSyncError::AlreadySetup))?;
         match pool {
-            RedisPool::Config(cfg) => {
-                let (addr, pool_config) = *cfg;
-
+            RedisPool::Config(addr, pool_config) => {
                 let client = Client::open(addr)
                     .map_err(|e| errs::Err::with_source(RedisSyncError::FailToOpenClient, e))?;
 


### PR DESCRIPTION
The `Config` is kept as an enum variant along with the `Pool`. Putting the `Config` in a `Box` would reduce the size to just a pointer to the heap, but it would increase the cost of heap allocation. However, if the `Config` size is small, there is no point in intentionally increasing heap allocation costs by using a `Box`. Therefore, I am changing it so that small `Config` sizes are not placed in a `Box`.