### PR TITLE
update!: renamed to RedisPubSubMsgDataSrc and RedisPubSubMsgDataConn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ pub mod pubsub {
             feature = "cluster-sync"
         )))
     )]
-    pub use crate::pubsub_sync::{RedisPubSubDataConn, RedisPubSubDataSrc};
+    pub use crate::pubsub_sync::{RedisPubSubMsgDataConn, RedisPubSubMsgDataSrc};
 
     #[cfg(any(
         feature = "standalone-async",
@@ -160,7 +160,7 @@ pub mod pubsub {
             feature = "cluster-async"
         )))
     )]
-    pub use crate::pubsub_async::{RedisPubSubAsyncDataConn, RedisPubSubAsyncDataSrc};
+    pub use crate::pubsub_async::{RedisPubSubMsgAsyncDataConn, RedisPubSubMsgAsyncDataSrc};
 
     #[cfg(feature = "standalone-sync")]
     #[cfg_attr(docsrs, doc(cfg(feature = "standalone-sync")))]

--- a/src/pubsub_async/mod.rs
+++ b/src/pubsub_async/mod.rs
@@ -11,11 +11,11 @@ use std::sync::Arc;
 /// This structure allows a received Pub/Sub message to be passed through the `sabi` data access
 /// layer in an asynchronous context. It implements `DataConn`, enabling it to be retrieved by a
 /// data access object.
-pub struct RedisPubSubAsyncDataConn {
+pub struct RedisPubSubMsgAsyncDataConn {
     msg: Arc<Msg>,
 }
 
-impl RedisPubSubAsyncDataConn {
+impl RedisPubSubMsgAsyncDataConn {
     fn new(msg: Arc<Msg>) -> Self {
         Self { msg }
     }
@@ -26,7 +26,7 @@ impl RedisPubSubAsyncDataConn {
     }
 }
 
-impl DataConn for RedisPubSubAsyncDataConn {
+impl DataConn for RedisPubSubMsgAsyncDataConn {
     async fn commit_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
         Ok(())
     }
@@ -42,7 +42,7 @@ impl DataConn for RedisPubSubAsyncDataConn {
 /// # Examples
 ///
 /// ```rust,ignore
-/// use sabi_redis::pubsub_async::{RedisPubSubAsyncDataSrc, RedisPubSubAsyncDataConn};
+/// use sabi_redis::pubsub::{RedisPubSubMsgAsyncDataSrc, RedisPubSubMsgAsyncDataConn};
 /// use sabi::tokio::DataHub;
 /// use futures::StreamExt;
 ///
@@ -54,37 +54,37 @@ impl DataConn for RedisPubSubAsyncDataConn {
 /// # let msg = stream.next().await.unwrap();
 ///
 /// let mut data = DataHub::new();
-/// data.uses("redis/pubsub", RedisPubSubAsyncDataSrc::new(msg));
+/// data.uses("redis/pubsub", RedisPubSubMsgAsyncDataSrc::new(msg));
 ///
 /// data.run_async(|acc: &mut DataHub| async move {
-///     let conn = acc.get_data_conn_async::<RedisPubSubAsyncDataConn>("redis/pubsub").await?;
+///     let conn = acc.get_data_conn_async::<RedisPubSubMsgAsyncDataConn>("redis/pubsub").await?;
 ///     let message = conn.get_message();
 ///     // Process the message...
 ///     Ok(())
 /// }).await.unwrap();
 /// # }
 /// ```
-pub struct RedisPubSubAsyncDataSrc {
+pub struct RedisPubSubMsgAsyncDataSrc {
     msg: Arc<Msg>,
 }
 
-impl RedisPubSubAsyncDataSrc {
-    /// Creates a new `RedisPubSubAsyncDataSrc` with the given Redis message.
+impl RedisPubSubMsgAsyncDataSrc {
+    /// Creates a new `RedisPubSubMsgAsyncDataSrc` with the given Redis message.
     pub fn new(msg: Msg) -> Self {
         Self { msg: Arc::new(msg) }
     }
 }
 
-impl DataSrc<RedisPubSubAsyncDataConn> for RedisPubSubAsyncDataSrc {
+impl DataSrc<RedisPubSubMsgAsyncDataConn> for RedisPubSubMsgAsyncDataSrc {
     async fn setup_async(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
         Ok(())
     }
 
     fn close(&mut self) {}
 
-    async fn create_data_conn_async(&mut self) -> errs::Result<Box<RedisPubSubAsyncDataConn>> {
+    async fn create_data_conn_async(&mut self) -> errs::Result<Box<RedisPubSubMsgAsyncDataConn>> {
         let msg = Arc::clone(&self.msg);
-        Ok(Box::new(RedisPubSubAsyncDataConn::new(msg)))
+        Ok(Box::new(RedisPubSubMsgAsyncDataConn::new(msg)))
     }
 }
 
@@ -109,7 +109,7 @@ mod unit_tests {
     trait SampleAsyncDataAcc1: DataAcc {
         async fn greet_async(&mut self) -> errs::Result<String> {
             let data_conn = self
-                .get_data_conn_async::<RedisPubSubAsyncDataConn>("redis/pubsub")
+                .get_data_conn_async::<RedisPubSubMsgAsyncDataConn>("redis/pubsub")
                 .await?;
             let msg = data_conn.get_message();
             let payload: String = msg.get_payload().unwrap();
@@ -153,7 +153,7 @@ mod unit_tests {
                 let msg = stream.next().await.unwrap();
 
                 let mut data = DataHub::new();
-                data.uses("redis/pubsub", RedisPubSubAsyncDataSrc::new(msg));
+                data.uses("redis/pubsub", RedisPubSubMsgAsyncDataSrc::new(msg));
                 if data.run_async(logic!(sample_logic)).await.is_ok() {
                     break;
                 }

--- a/src/pubsub_sync/cluster.rs
+++ b/src/pubsub_sync/cluster.rs
@@ -156,7 +156,7 @@ where
 mod unit_tests {
     use super::*;
     use crate::cluster_sync::{RedisClusterDataConn, RedisClusterDataSrc};
-    use crate::pubsub::{RedisPubSubDataConn, RedisPubSubDataSrc};
+    use crate::pubsub::{RedisPubSubMsgDataConn, RedisPubSubMsgDataSrc};
     use override_macro::{overridable, override_with};
     use redis::{ControlFlow, TypedCommands};
     use sabi::{DataAcc, DataHub};
@@ -192,7 +192,7 @@ mod unit_tests {
         }
 
         fn receive_greet(&mut self) -> errs::Result<String> {
-            let data_conn = self.get_data_conn::<RedisPubSubDataConn>("redis/pubsub")?;
+            let data_conn = self.get_data_conn::<RedisPubSubMsgDataConn>("redis/pubsub")?;
             let msg = data_conn.get_message();
             let payload: String = msg.get_payload().unwrap();
             Ok(payload)
@@ -234,7 +234,7 @@ mod unit_tests {
             pubsub.subscribe("channel-3");
             let n = pubsub.receive(|msg| {
                 let mut data = DataHub::new();
-                data.uses("redis/pubsub", RedisPubSubDataSrc::new(msg));
+                data.uses("redis/pubsub", RedisPubSubMsgDataSrc::new(msg));
                 data.run(subscribe_logic).unwrap();
                 ControlFlow::Break(1)
             })?;

--- a/src/pubsub_sync/mod.rs
+++ b/src/pubsub_sync/mod.rs
@@ -32,11 +32,11 @@ use std::sync::Arc;
 ///
 /// This structure allows a received Pub/Sub message to be passed through the `sabi` data access
 /// layer. It implements `DataConn`, enabling it to be retrieved by a data access object.
-pub struct RedisPubSubDataConn {
+pub struct RedisPubSubMsgDataConn {
     msg: Arc<Msg>,
 }
 
-impl RedisPubSubDataConn {
+impl RedisPubSubMsgDataConn {
     fn new(msg: Arc<Msg>) -> Self {
         Self { msg }
     }
@@ -47,7 +47,7 @@ impl RedisPubSubDataConn {
     }
 }
 
-impl DataConn for RedisPubSubDataConn {
+impl DataConn for RedisPubSubMsgDataConn {
     fn commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
         Ok(())
     }
@@ -63,7 +63,7 @@ impl DataConn for RedisPubSubDataConn {
 /// # Examples
 ///
 /// ```rust,ignore
-/// use sabi_redis::pubsub::{RedisPubSubDataSrc, RedisPubSubDataConn};
+/// use sabi_redis::pubsub::{RedisPubSubMsgDataSrc, RedisPubSubMsgDataConn};
 /// use sabi::DataHub;
 ///
 /// // Assume `msg` is a `redis::Msg` received from a subscriber.
@@ -74,36 +74,36 @@ impl DataConn for RedisPubSubDataConn {
 /// # let msg = pubsub.get_message().unwrap();
 ///
 /// let mut data = DataHub::new();
-/// data.uses("redis/pubsub", RedisPubSubDataSrc::new(msg));
+/// data.uses("redis/pubsub", RedisPubSubMsgDataSrc::new(msg));
 ///
 /// data.run(|acc: &mut DataHub| {
-///     let conn = acc.get_data_conn::<RedisPubSubDataConn>("redis/pubsub")?;
+///     let conn = acc.get_data_conn::<RedisPubSubMsgDataConn>("redis/pubsub")?;
 ///     let message = conn.get_message();
 ///     // Process the message...
 ///     Ok(())
 /// }).unwrap();
 /// ```
-pub struct RedisPubSubDataSrc {
+pub struct RedisPubSubMsgDataSrc {
     msg: Arc<Msg>,
 }
 
-impl RedisPubSubDataSrc {
-    /// Creates a new `RedisPubSubDataSrc` with the given Redis message.
+impl RedisPubSubMsgDataSrc {
+    /// Creates a new `RedisPubSubMsgDataSrc` with the given Redis message.
     pub fn new(msg: Msg) -> Self {
         Self { msg: Arc::new(msg) }
     }
 }
 
-impl DataSrc<RedisPubSubDataConn> for RedisPubSubDataSrc {
+impl DataSrc<RedisPubSubMsgDataConn> for RedisPubSubMsgDataSrc {
     fn setup(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
         Ok(())
     }
 
     fn close(&mut self) {}
 
-    fn create_data_conn(&mut self) -> errs::Result<Box<RedisPubSubDataConn>> {
+    fn create_data_conn(&mut self) -> errs::Result<Box<RedisPubSubMsgDataConn>> {
         let msg = Arc::clone(&self.msg);
-        Ok(Box::new(RedisPubSubDataConn::new(msg)))
+        Ok(Box::new(RedisPubSubMsgDataConn::new(msg)))
     }
 }
 
@@ -125,7 +125,7 @@ mod unit_tests {
     #[overridable]
     trait SampleDataAcc1: sabi::DataAcc {
         fn greet(&mut self) -> errs::Result<String> {
-            let data_conn = self.get_data_conn::<RedisPubSubDataConn>("redis/pubsub")?;
+            let data_conn = self.get_data_conn::<RedisPubSubMsgDataConn>("redis/pubsub")?;
             let msg = data_conn.get_message();
             let payload: String = msg.get_payload().unwrap();
             Ok(payload)
@@ -167,7 +167,7 @@ mod unit_tests {
                 let msg = pubsub.get_message().unwrap();
 
                 let mut data = sabi::DataHub::new();
-                data.uses("redis/pubsub", RedisPubSubDataSrc::new(msg));
+                data.uses("redis/pubsub", RedisPubSubMsgDataSrc::new(msg));
                 if data.run(sample_logic).is_ok() {
                     break;
                 }

--- a/src/pubsub_sync/sentinel.rs
+++ b/src/pubsub_sync/sentinel.rs
@@ -230,7 +230,7 @@ where
 #[cfg(test)]
 mod unit_tests {
     use super::*;
-    use crate::pubsub::{RedisPubSubDataConn, RedisPubSubDataSrc};
+    use crate::pubsub::{RedisPubSubMsgDataConn, RedisPubSubMsgDataSrc};
     use crate::sentinel_sync::{RedisSentinelDataConn, RedisSentinelDataSrc};
     use override_macro::{overridable, override_with};
     use redis::{ControlFlow, TypedCommands};
@@ -267,7 +267,7 @@ mod unit_tests {
         }
 
         fn receive_greet(&mut self) -> errs::Result<String> {
-            let data_conn = self.get_data_conn::<RedisPubSubDataConn>("redis/pubsub")?;
+            let data_conn = self.get_data_conn::<RedisPubSubMsgDataConn>("redis/pubsub")?;
             let msg = data_conn.get_message();
             let payload: String = msg.get_payload().unwrap();
             Ok(payload)
@@ -315,7 +315,7 @@ mod unit_tests {
             pubsub.subscribe("channel-2");
             let n = pubsub.receive(|msg| {
                 let mut data = DataHub::new();
-                data.uses("redis/pubsub", RedisPubSubDataSrc::new(msg));
+                data.uses("redis/pubsub", RedisPubSubMsgDataSrc::new(msg));
                 data.run(subscribe_logic).unwrap();
                 ControlFlow::Break(1)
             })?;

--- a/src/pubsub_sync/standalone.rs
+++ b/src/pubsub_sync/standalone.rs
@@ -153,7 +153,7 @@ where
 #[cfg(test)]
 mod unit_tests {
     use super::*;
-    use crate::pubsub::{RedisPubSubDataConn, RedisPubSubDataSrc};
+    use crate::pubsub::{RedisPubSubMsgDataConn, RedisPubSubMsgDataSrc};
     use crate::standalone_sync::{RedisDataConn, RedisDataSrc};
     use override_macro::{overridable, override_with};
     use redis::{ControlFlow, TypedCommands};
@@ -190,7 +190,7 @@ mod unit_tests {
         }
 
         fn receive_greet(&mut self) -> errs::Result<String> {
-            let data_conn = self.get_data_conn::<RedisPubSubDataConn>("redis/pubsub")?;
+            let data_conn = self.get_data_conn::<RedisPubSubMsgDataConn>("redis/pubsub")?;
             let msg = data_conn.get_message();
             let payload: String = msg.get_payload().unwrap();
             Ok(payload)
@@ -221,7 +221,7 @@ mod unit_tests {
             pubsub.subscribe("channel-1");
             let n = pubsub.receive(|msg| {
                 let mut data = DataHub::new();
-                data.uses("redis/pubsub", RedisPubSubDataSrc::new(msg));
+                data.uses("redis/pubsub", RedisPubSubMsgDataSrc::new(msg));
                 data.run(subscribe_logic).unwrap();
                 ControlFlow::Break(1)
             })?;


### PR DESCRIPTION
This PR renames `::pubsub::RedisPubSubDataSrc` to `::pubsub::RedisPubSubMsgDataSrc` and `::pubsub::RedisPubSubDataConn` to `::pubsub::RedisPubSubMsgDataConn` for a PubSub message.