### PR TITLE
update!: changed to hold not a Pool but a Connection within DataConn

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ trait RedisSayingDataAcc: sabi::DataAcc {
         let data_conn = self.get_data_conn::<RedisDataConn>("redis")?;
 
         // Get a Redis connection to execute Redis synchronous commands.
-        let mut redis_conn = data_conn.get_connection()?;
+        let redis_conn = data_conn.get_connection();
 
         redis_conn.set("greeting", greeting)
             .map_err(|e| errs::Err::with_source("fail to set greeting", e))?;
@@ -186,7 +186,7 @@ trait RedisSayingDataAcc: sabi::tokio::DataAcc {
         let data_conn = self.get_data_conn_async::<RedisAsyncDataConn>("redis").await?;
 
         // Get an asynchronous Redis connection to execute Redis commands.
-        let mut redis_conn = data_conn.get_connection_async().await?;
+        let redis_conn = data_conn.get_connection();
 
         redis_conn.set("greeting", greeting)
             .await

--- a/src/cluster_async.rs
+++ b/src/cluster_async.rs
@@ -2,8 +2,7 @@
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
-use deadpool_redis::cluster::{Config, Connection, Pool, PoolConfig, Runtime};
-use deadpool_redis::Timeouts;
+use deadpool_redis::cluster::{ClusterConnection, Config, Connection, Pool, PoolConfig, Runtime};
 use sabi::tokio::{AsyncGroup, DataConn, DataSrc};
 
 use std::future::Future;
@@ -45,117 +44,67 @@ type BoxedFuture = pin::Pin<Box<dyn Future<Output = errs::Result<()>> + Send + '
 /// }
 /// ```
 pub struct RedisClusterAsyncDataConn {
-    pool: Pool,
+    conn: Connection,
     pre_commit_vec: Vec<BoxedFuture>,
     post_commit_vec: Vec<BoxedFuture>,
     force_back_vec: Vec<BoxedFuture>,
 }
 
 impl RedisClusterAsyncDataConn {
-    fn new(pool: Pool) -> Self {
+    fn new(conn: Connection) -> Self {
         Self {
-            pool,
+            conn,
             pre_commit_vec: Vec::new(),
             post_commit_vec: Vec::new(),
             force_back_vec: Vec::new(),
         }
     }
 
-    /// Gets an asynchronous cluster connection from the pool.
+    /// Gets an asynchronous cluster connection.
     ///
     /// # Returns
-    /// Returns a `Result` containing a `Connection` on success,
-    /// or a `RedisClusterAsyncError::FailToGetConnectionFromPool` wrapped in `errs::Err` on failure.
-    pub async fn get_connection_async(&mut self) -> errs::Result<Connection> {
-        self.pool.get().await.map_err(|e| {
-            errs::Err::with_source(RedisClusterAsyncError::FailToGetConnectionFromPool, e)
-        })
-    }
-
-    /// Gets an asynchronous cluster connection from the pool with specific timeouts.
-    ///
-    /// # Arguments
-    /// * `timeouts` - A `Timeouts` configuration for getting a connection.
-    ///
-    /// # Returns
-    /// Returns a `Result` containing a `Connection` on success,
-    /// or a `RedisClusterAsyncError::FailToGetConnectionFromPool` wrapped in `errs::Err` on failure.
-    pub async fn get_connection_with_timeout_async(
-        &mut self,
-        timeouts: Timeouts,
-    ) -> errs::Result<Connection> {
-        self.pool.timeout_get(&timeouts).await.map_err(|e| {
-            errs::Err::with_source(RedisClusterAsyncError::FailToGetConnectionFromPool, e)
-        })
+    /// Returns a mutable reference to a `ClusterConnection`.
+    pub fn get_connection(&mut self) -> &mut ClusterConnection {
+        &mut self.conn
     }
 
     /// Adds an asynchronous function to be executed before a commit occurs.
     ///
     /// # Arguments
-    /// * `f` - An async closure or function that takes a `Connection` and returns a `Future`.
+    /// * `f` - An async closure or function that takes a `ClusterConnection` and returns a `Future`.
     pub async fn add_pre_commit_async<F, Fut>(&mut self, mut f: F)
     where
-        F: FnMut(Connection) -> Fut,
+        F: FnMut(ClusterConnection) -> Fut,
         Fut: Future<Output = errs::Result<()>> + Send + 'static,
     {
-        match self.pool.get().await {
-            Ok(pooled_conn) => {
-                let fut = f(pooled_conn);
-                self.pre_commit_vec.push(Box::pin(fut))
-            }
-            Err(e) => self.pre_commit_vec.push(Box::pin(async move {
-                Err(errs::Err::with_source(
-                    RedisClusterAsyncError::FailToGetConnectionFromPool,
-                    e,
-                ))
-            })),
-        }
+        let fut = f(self.conn.clone());
+        self.pre_commit_vec.push(Box::pin(fut))
     }
 
     /// Adds an asynchronous function to be executed after a successful commit.
     ///
     /// # Arguments
-    /// * `f` - An async closure or function that takes a `Connection` and returns a `Future`.
+    /// * `f` - An async closure or function that takes a `ClusterConnection` and returns a `Future`.
     pub async fn add_post_commit_async<F, Fut>(&mut self, mut f: F)
     where
-        F: FnMut(Connection) -> Fut,
+        F: FnMut(ClusterConnection) -> Fut,
         Fut: Future<Output = errs::Result<()>> + Send + 'static,
     {
-        match self.pool.get().await {
-            Ok(pooled_conn) => {
-                let fut = f(pooled_conn);
-                self.post_commit_vec.push(Box::pin(fut))
-            }
-            Err(e) => self.post_commit_vec.push(Box::pin(async move {
-                Err(errs::Err::with_source(
-                    RedisClusterAsyncError::FailToGetConnectionFromPool,
-                    e,
-                ))
-            })),
-        }
+        let fut = f(self.conn.clone());
+        self.post_commit_vec.push(Box::pin(fut))
     }
 
     /// Adds an asynchronous function to be executed when a rollback occurs.
     ///
     /// # Arguments
-    /// * `f` - An async closure or function that takes a `Connection` and returns a `Future`.
+    /// * `f` - An async closure or function that takes a `ClusterConnection` and returns a `Future`.
     pub async fn add_force_back_async<F, Fut>(&mut self, mut f: F)
     where
-        F: FnMut(Connection) -> Fut,
+        F: FnMut(ClusterConnection) -> Fut,
         Fut: Future<Output = errs::Result<()>> + Send + 'static,
     {
-        match self.pool.get().await {
-            Ok(pooled_conn) => {
-                let fut = f(pooled_conn);
-                self.force_back_vec.push(Box::pin(fut))
-            }
-            Err(e) => self.force_back_vec.push(Box::pin(async move {
-                Err(errs::Err::with_source(
-                    RedisClusterAsyncError::FailToGetConnectionFromPool,
-                    e,
-                ))
-            })),
-        }
+        let fut = f(self.conn.clone());
+        self.force_back_vec.push(Box::pin(fut))
     }
 }
 
@@ -323,7 +272,13 @@ impl DataSrc<RedisClusterAsyncDataConn> for RedisClusterAsyncDataSrc {
             .as_mut()
             .ok_or_else(|| errs::Err::new(RedisClusterAsyncError::NotSetupYet))?;
         match pool {
-            RedisPool::Object(pool) => Ok(Box::new(RedisClusterAsyncDataConn::new(pool.clone()))),
+            RedisPool::Object(pool) => match pool.get().await {
+                Ok(conn) => Ok(Box::new(RedisClusterAsyncDataConn::new(conn))),
+                Err(e) => Err(errs::Err::with_source(
+                    RedisClusterAsyncError::FailToGetConnectionFromPool,
+                    e,
+                )),
+            },
             _ => Err(errs::Err::new(RedisClusterAsyncError::NotSetupYet)),
         }
     }
@@ -351,7 +306,7 @@ mod unit_tests {
             let data_conn = self
                 .get_data_conn_async::<RedisClusterAsyncDataConn>("redis")
                 .await?;
-            let mut conn = data_conn.get_connection_async().await?;
+            let conn = data_conn.get_connection();
             conn.get("sample_cluster_async")
                 .await
                 .map_err(|e| errs::Err::with_source(SampleClusterAsyncError::FailToGetValue, e))
@@ -360,9 +315,7 @@ mod unit_tests {
             let data_conn = self
                 .get_data_conn_async::<RedisClusterAsyncDataConn>("redis")
                 .await?;
-            let mut conn = data_conn
-                .get_connection_with_timeout_async(Timeouts::wait_millis(1000))
-                .await?;
+            let conn = data_conn.get_connection();
             conn.set("sample_cluster_async", val)
                 .await
                 .map_err(|e| errs::Err::with_source(SampleClusterAsyncError::FailToSetValue, e))
@@ -371,7 +324,7 @@ mod unit_tests {
             let data_conn = self
                 .get_data_conn_async::<RedisClusterAsyncDataConn>("redis")
                 .await?;
-            let mut conn = data_conn.get_connection_async().await?;
+            let conn = data_conn.get_connection();
             conn.del("sample_cluster_async")
                 .await
                 .map_err(|e| errs::Err::with_source(SampleClusterAsyncError::FailToDelValue, e))
@@ -381,13 +334,15 @@ mod unit_tests {
             let data_conn = self
                 .get_data_conn_async::<RedisClusterAsyncDataConn>("redis")
                 .await?;
-            let mut conn = data_conn
-                .get_connection_with_timeout_async(Timeouts::wait_millis(1000))
-                .await?;
 
-            conn.set::<&str, &str, ()>("sample_force_back_cluster_async", val)
-                .await
-                .map_err(|e| errs::Err::with_source(SampleClusterAsyncError::FailToSetValue, e))?;
+            {
+                let conn = data_conn.get_connection();
+                conn.set::<&str, &str, ()>("sample_force_back_cluster_async", val)
+                    .await
+                    .map_err(|e| {
+                        errs::Err::with_source(SampleClusterAsyncError::FailToSetValue, e)
+                    })?;
+            }
 
             data_conn
                 .add_force_back_async(async |mut conn| {
@@ -397,9 +352,14 @@ mod unit_tests {
                 })
                 .await;
 
-            conn.set::<&str, &str, ()>("sample_force_back_cluster_async_2", val)
-                .await
-                .map_err(|e| errs::Err::with_source(SampleClusterAsyncError::FailToSetValue, e))?;
+            {
+                let conn = data_conn.get_connection();
+                conn.set::<&str, &str, ()>("sample_force_back_cluster_async_2", val)
+                    .await
+                    .map_err(|e| {
+                        errs::Err::with_source(SampleClusterAsyncError::FailToSetValue, e)
+                    })?;
+            }
 
             data_conn
                 .add_force_back_async(async |mut conn| {

--- a/src/cluster_sync.rs
+++ b/src/cluster_sync.rs
@@ -9,7 +9,7 @@ use redis::cluster::{ClusterClient, ClusterClientBuilder, ClusterConnection};
 use redis::IntoConnectionInfo;
 
 use std::fmt::Debug;
-use std::{mem, time};
+use std::mem;
 
 /// The error type for synchronous Redis Cluster operations.
 #[derive(Debug)]
@@ -29,7 +29,7 @@ pub enum RedisClusterSyncError {
 #[allow(clippy::type_complexity)]
 /// A data connection for a Redis Cluster, providing synchronous operations.
 ///
-/// This structure holds a connection pool for a Redis Cluster and allows for adding hooks
+/// This structure holds a pooled connection for a Redis Cluster and allows for adding hooks
 /// (pre-commit, post-commit, and force-back) that are executed during the lifecycle
 /// of a data operation managed by `sabi`.
 ///
@@ -42,22 +42,22 @@ pub enum RedisClusterSyncError {
 /// trait MyDataAcc: DataAcc {
 ///     fn set_value(&mut self, key: &str, val: &str) -> errs::Result<()> {
 ///         let data_conn = self.get_data_conn::<RedisClusterDataConn>("redis")?;
-///         let mut conn = data_conn.get_connection()?;
+///         let conn = data_conn.get_connection();
 ///         conn.set(key, val).map_err(|e| errs::Err::with_source("fail", e))
 ///     }
 /// }
 /// ```
 pub struct RedisClusterDataConn {
-    pool: Pool<ClusterClient>,
+    conn: PooledConnection<ClusterClient>,
     pre_commit_vec: Vec<Box<dyn FnMut(&mut ClusterConnection) -> errs::Result<()>>>,
     post_commit_vec: Vec<Box<dyn FnMut(&mut ClusterConnection) -> errs::Result<()>>>,
     force_back_vec: Vec<Box<dyn FnMut(&mut ClusterConnection) -> errs::Result<()>>>,
 }
 
 impl RedisClusterDataConn {
-    fn new(pool: Pool<ClusterClient>) -> Self {
+    fn new(conn: PooledConnection<ClusterClient>) -> Self {
         Self {
-            pool,
+            conn,
             pre_commit_vec: Vec::new(),
             post_commit_vec: Vec::new(),
             force_back_vec: Vec::new(),
@@ -67,37 +67,9 @@ impl RedisClusterDataConn {
     /// Gets a cluster connection from the pool.
     ///
     /// # Returns
-    /// Returns a `Result` containing a `PooledConnection<ClusterClient>` on success,
-    /// or a `RedisClusterSyncError::FailToGetConnectionFromPool` wrapped in `errs::Err` on failure.
-    pub fn get_connection(&mut self) -> errs::Result<PooledConnection<ClusterClient>> {
-        self.pool.get().map_err(|e| {
-            errs::Err::with_source(RedisClusterSyncError::FailToGetConnectionFromPool, e)
-        })
-    }
-
-    /// Gets a cluster connection from the pool with a specific timeout.
-    ///
-    /// # Arguments
-    /// * `timeout` - A `Duration` to wait for a connection before failing.
-    ///
-    /// # Returns
-    /// Returns a `Result` containing a `PooledConnection<ClusterClient>` on success,
-    /// or a `RedisClusterSyncError::FailToGetConnectionFromPool` wrapped in `errs::Err` on failure.
-    pub fn get_connection_with_timeout(
-        &self,
-        timeout: time::Duration,
-    ) -> errs::Result<PooledConnection<ClusterClient>> {
-        self.pool.get_timeout(timeout).map_err(|e| {
-            errs::Err::with_source(RedisClusterSyncError::FailToGetConnectionFromPool, e)
-        })
-    }
-
-    /// Tries to get a cluster connection from the pool immediately without waiting.
-    ///
-    /// # Returns
-    /// Returns `Some(PooledConnection<ClusterClient>)` if a connection is available, otherwise `None`.
-    pub fn try_get_connection(&self) -> Option<PooledConnection<ClusterClient>> {
-        self.pool.try_get()
+    /// Returns a mutable reference to a `PooledConnection<ClusterClient>`.
+    pub fn get_connection(&mut self) -> &mut PooledConnection<ClusterClient> {
+        &mut self.conn
     }
 
     /// Adds a function to be executed before a commit occurs in the `sabi` lifecycle.
@@ -136,18 +108,10 @@ impl RedisClusterDataConn {
 
 impl DataConn for RedisClusterDataConn {
     fn pre_commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
-        match self.pool.get() {
-            Ok(mut conn) => {
-                for f in self.pre_commit_vec.iter_mut() {
-                    f(&mut conn)?;
-                }
-                Ok(())
-            }
-            Err(e) => Err(errs::Err::with_source(
-                RedisClusterSyncError::FailToGetConnectionFromPool,
-                e,
-            )),
+        for f in self.pre_commit_vec.iter_mut() {
+            f(&mut self.conn)?;
         }
+        Ok(())
     }
 
     fn commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
@@ -155,19 +119,10 @@ impl DataConn for RedisClusterDataConn {
     }
 
     fn post_commit(&mut self, _ag: &mut AsyncGroup) {
-        match self.pool.get() {
-            Ok(mut conn) => {
-                for f in self.post_commit_vec.iter_mut() {
-                    // for error notification
-                    let _ = f(&mut conn);
-                }
-            }
-            Err(e) => {
-                // for error notification
-                let _ =
-                    errs::Err::with_source(RedisClusterSyncError::FailToGetConnectionFromPool, e);
-            }
-        };
+        for f in self.post_commit_vec.iter_mut() {
+            // for error notification
+            let _ = f(&mut self.conn);
+        }
     }
 
     fn rollback(&mut self, _ag: &mut AsyncGroup) {}
@@ -177,25 +132,17 @@ impl DataConn for RedisClusterDataConn {
     }
 
     fn force_back(&mut self, _ag: &mut AsyncGroup) {
-        match self.pool.get() {
-            Ok(mut conn) => {
-                for f in self.force_back_vec.iter_mut().rev() {
-                    // for error notification
-                    let _ = f(&mut conn);
-                }
-            }
-            Err(e) => {
-                // for error notification
-                let _ =
-                    errs::Err::with_source(RedisClusterSyncError::FailToGetConnectionFromPool, e);
-            }
-        };
+        for f in self.force_back_vec.iter_mut().rev() {
+            // for error notification
+            let _ = f(&mut self.conn);
+        }
     }
 
     fn close(&mut self) {}
 }
 
-/// A data source for Redis Cluster, used to initialize and provide `RedisClusterDataConn` instances.
+/// A data source for Redis Cluster, used to initialize and provide `RedisClusterDataConn`
+/// instances.
 ///
 /// This struct implements the `DataSrc` trait from the `sabi` library.
 ///
@@ -303,7 +250,13 @@ impl DataSrc<RedisClusterDataConn> for RedisClusterDataSrc {
             .as_mut()
             .ok_or_else(|| errs::Err::new(RedisClusterSyncError::NotSetupYet))?;
         match pool {
-            RedisPool::Object(pool) => Ok(Box::new(RedisClusterDataConn::new(pool.clone()))),
+            RedisPool::Object(pool) => match pool.get() {
+                Ok(conn) => Ok(Box::new(RedisClusterDataConn::new(conn))),
+                Err(e) => Err(errs::Err::with_source(
+                    RedisClusterSyncError::FailToGetConnectionFromPool,
+                    e,
+                )),
+            },
             _ => Err(errs::Err::new(RedisClusterSyncError::NotSetupYet)),
         }
     }
@@ -328,38 +281,42 @@ mod unit_tests {
     trait RedisClusterSampleDataAcc: DataAcc {
         fn get_sample_key(&mut self) -> errs::Result<Option<String>> {
             let data_conn = self.get_data_conn::<RedisClusterDataConn>("redis")?;
-            let mut conn = data_conn.get_connection()?;
+            let conn = data_conn.get_connection();
             conn.get("sample_cluster")
                 .map_err(|e| errs::Err::with_source(SampleError::FailToGetValue, e))
         }
         fn set_sample_key(&mut self, val: &str) -> errs::Result<()> {
             let data_conn = self.get_data_conn::<RedisClusterDataConn>("redis")?;
-            let mut conn =
-                data_conn.get_connection_with_timeout(time::Duration::from_millis(1000))?;
+            let conn = data_conn.get_connection();
             conn.set("sample_cluster", val)
                 .map_err(|e| errs::Err::with_source(SampleError::FailToSetValue, e))
         }
         fn del_sample_key(&mut self) -> errs::Result<()> {
             let data_conn = self.get_data_conn::<RedisClusterDataConn>("redis")?;
-            let mut conn = data_conn.try_get_connection().unwrap();
+            let conn = data_conn.get_connection();
             conn.del("sample_cluster")
                 .map_err(|e| errs::Err::with_source(SampleError::FailToDelValue, e))
         }
 
         fn set_sample_key_with_force_back(&mut self, val: &str) -> errs::Result<()> {
             let data_conn = self.get_data_conn::<RedisClusterDataConn>("redis")?;
-            let mut conn = data_conn.get_connection()?;
 
-            conn.set::<&str, &str, ()>("sample_force_back_cluster", val)
-                .map_err(|e| errs::Err::with_source(SampleError::FailToSetValue, e))?;
+            {
+                let conn = data_conn.get_connection();
+                conn.set::<&str, &str, ()>("sample_force_back_cluster", val)
+                    .map_err(|e| errs::Err::with_source(SampleError::FailToSetValue, e))?;
+            }
 
             data_conn.add_force_back(|conn| {
                 conn.del("sample_force_back_cluster")
                     .map_err(|e| errs::Err::with_source("fail to force back", e))
             });
 
-            conn.set::<&str, &str, ()>("sample_force_back_cluster_2", val)
-                .map_err(|e| errs::Err::with_source(SampleError::FailToSetValue, e))?;
+            {
+                let conn = data_conn.get_connection();
+                conn.set::<&str, &str, ()>("sample_force_back_cluster_2", val)
+                    .map_err(|e| errs::Err::with_source(SampleError::FailToSetValue, e))?;
+            }
 
             data_conn.add_force_back(|conn| {
                 conn.del("sample_force_back_cluster_2")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //!   - **Standalone**: For a standalone Redis server.
 //!   - **Sentinel**: For a Redis Sentinel setup.
 //!   - **Cluster**: For a Redis Cluster setup.
-//!   Each of these subscribers has both **synchronous** and **asynchronous** implementations.
+//!     Each of these subscribers has both **synchronous** and **asynchronous** implementations.
 //!
 //! Each configuration has both **synchronous** and **asynchronous** (compatible with `tokio`)
 //! implementations, which can be enabled via features.

--- a/src/pubsub_async/cluster.rs
+++ b/src/pubsub_async/cluster.rs
@@ -192,7 +192,7 @@ mod unit_tests {
             let data_conn = self
                 .get_data_conn_async::<RedisClusterAsyncDataConn>("redis")
                 .await?;
-            let mut conn = data_conn.get_connection_async().await?;
+            let conn = data_conn.get_connection();
             time::sleep(time::Duration::from_millis(100)).await;
             conn.publish("channel-1", s).await.unwrap();
             Ok(())

--- a/src/pubsub_async/sentinel.rs
+++ b/src/pubsub_async/sentinel.rs
@@ -288,7 +288,7 @@ mod unit_tests {
             let data_conn = self
                 .get_data_conn_async::<RedisSentinelAsyncDataConn>("redis")
                 .await?;
-            let mut conn = data_conn.get_connection_async().await?;
+            let conn = data_conn.get_connection();
             time::sleep(time::Duration::from_millis(100)).await;
             conn.publish("channel-1", s).await.unwrap();
             Ok(())

--- a/src/pubsub_async/standalone.rs
+++ b/src/pubsub_async/standalone.rs
@@ -184,7 +184,7 @@ mod unit_tests {
             let data_conn = self
                 .get_data_conn_async::<RedisAsyncDataConn>("redis")
                 .await?;
-            let mut conn = data_conn.get_connection_async().await?;
+            let conn = data_conn.get_connection();
             time::sleep(time::Duration::from_millis(100)).await;
             conn.publish("channel-1", s).await.unwrap();
             Ok(())

--- a/src/pubsub_sync/cluster.rs
+++ b/src/pubsub_sync/cluster.rs
@@ -185,7 +185,7 @@ mod unit_tests {
     trait RedisPubSubClusterDataAcc: DataAcc {
         fn say_greet(&mut self, s: &str) -> errs::Result<()> {
             let data_conn = self.get_data_conn::<RedisClusterDataConn>("redis")?;
-            let mut conn = data_conn.get_connection()?;
+            let conn = data_conn.get_connection();
             std::thread::sleep(std::time::Duration::from_millis(100));
             conn.publish("channel-3", s).unwrap();
             Ok(())

--- a/src/pubsub_sync/sentinel.rs
+++ b/src/pubsub_sync/sentinel.rs
@@ -260,7 +260,7 @@ mod unit_tests {
     trait RedisPubSubDataAcc: DataAcc {
         fn say_greet(&mut self, s: &str) -> errs::Result<()> {
             let data_conn = self.get_data_conn::<RedisSentinelDataConn>("redis")?;
-            let mut conn = data_conn.get_connection()?;
+            let conn = data_conn.get_connection();
             std::thread::sleep(std::time::Duration::from_millis(100));
             conn.publish("channel-2", s).unwrap();
             Ok(())

--- a/src/pubsub_sync/standalone.rs
+++ b/src/pubsub_sync/standalone.rs
@@ -183,7 +183,7 @@ mod unit_tests {
     trait RedisPubSubDataAcc: DataAcc {
         fn say_greet(&mut self, s: &str) -> errs::Result<()> {
             let data_conn = self.get_data_conn::<RedisDataConn>("redis")?;
-            let mut conn = data_conn.get_connection()?;
+            let conn = data_conn.get_connection();
             std::thread::sleep(std::time::Duration::from_millis(100));
             conn.publish("channel-1", s).unwrap();
             Ok(())

--- a/src/sentinel_async.rs
+++ b/src/sentinel_async.rs
@@ -3,7 +3,7 @@
 // See the file LICENSE in this distribution for more details.
 
 use deadpool_redis::sentinel::{Config, Connection, Pool, PoolConfig, Runtime, SentinelServerType};
-use deadpool_redis::Timeouts;
+use redis::aio::MultiplexedConnection;
 use sabi::tokio::{AsyncGroup, DataConn, DataSrc};
 
 use std::future::Future;
@@ -39,123 +39,73 @@ type BoxedFuture = pin::Pin<Box<dyn Future<Output = errs::Result<()>> + Send + '
 /// trait MyDataAcc: DataAcc {
 ///     async fn set_value(&mut self, key: &str, val: &str) -> errs::Result<()> {
 ///         let data_conn = self.get_data_conn_async::<RedisSentinelAsyncDataConn>("redis").await?;
-///         let mut conn = data_conn.get_connection_async().await?;
+///         let conn = data_conn.get_connection();
 ///         conn.set(key, val).await.map_err(|e| errs::Err::with_source("fail", e))
 ///     }
 /// }
 /// ```
 pub struct RedisSentinelAsyncDataConn {
-    pool: Pool,
+    conn: Connection,
     pre_commit_vec: Vec<BoxedFuture>,
     post_commit_vec: Vec<BoxedFuture>,
     force_back_vec: Vec<BoxedFuture>,
 }
 
 impl RedisSentinelAsyncDataConn {
-    fn new(pool: Pool) -> Self {
+    fn new(conn: Connection) -> Self {
         Self {
-            pool,
+            conn,
             pre_commit_vec: Vec::new(),
             post_commit_vec: Vec::new(),
             force_back_vec: Vec::new(),
         }
     }
 
-    /// Gets an asynchronous Sentinel-managed connection from the pool.
+    /// Gets an asynchronous Sentinel-managed connection.
     ///
     /// # Returns
-    /// Returns a `Result` containing a `Connection` on success,
-    /// or a `RedisSentinelAsyncError::FailToGetConnectionFromPool` wrapped in `errs::Err` on failure.
-    pub async fn get_connection_async(&mut self) -> errs::Result<Connection> {
-        self.pool.get().await.map_err(|e| {
-            errs::Err::with_source(RedisSentinelAsyncError::FailToGetConnectionFromPool, e)
-        })
-    }
-
-    /// Gets an asynchronous Sentinel-managed connection from the pool with specific timeouts.
-    ///
-    /// # Arguments
-    /// * `timeouts` - A `Timeouts` configuration for getting a connection.
-    ///
-    /// # Returns
-    /// Returns a `Result` containing a `Connection` on success,
-    /// or a `RedisSentinelAsyncError::FailToGetConnectionFromPool` wrapped in `errs::Err` on failure.
-    pub async fn get_connection_with_timeout_async(
-        &mut self,
-        timeouts: Timeouts,
-    ) -> errs::Result<Connection> {
-        self.pool.timeout_get(&timeouts).await.map_err(|e| {
-            errs::Err::with_source(RedisSentinelAsyncError::FailToGetConnectionFromPool, e)
-        })
+    /// Returns a mutable reference to a `MultiplexedConnection`.
+    pub fn get_connection(&mut self) -> &mut MultiplexedConnection {
+        &mut self.conn
     }
 
     /// Adds an asynchronous function to be executed before a commit occurs.
     ///
     /// # Arguments
-    /// * `f` - An async closure or function that takes a `Connection` and returns a `Future`.
+    /// * `f` - An async closure or function that takes a `MultiplexedConnection` and returns a `Future`.
     pub async fn add_pre_commit_async<F, Fut>(&mut self, mut f: F)
     where
-        F: FnMut(Connection) -> Fut,
+        F: FnMut(MultiplexedConnection) -> Fut,
         Fut: Future<Output = errs::Result<()>> + Send + 'static,
     {
-        match self.pool.get().await {
-            Ok(pooled_conn) => {
-                let fut = f(pooled_conn);
-                self.pre_commit_vec.push(Box::pin(fut))
-            }
-            Err(e) => self.pre_commit_vec.push(Box::pin(async move {
-                Err(errs::Err::with_source(
-                    RedisSentinelAsyncError::FailToGetConnectionFromPool,
-                    e,
-                ))
-            })),
-        }
+        let fut = f(self.conn.clone());
+        self.pre_commit_vec.push(Box::pin(fut))
     }
 
     /// Adds an asynchronous function to be executed after a successful commit.
     ///
     /// # Arguments
-    /// * `f` - An async closure or function that takes a `Connection` and returns a `Future`.
+    /// * `f` - An async closure or function that takes a `MultiplexedConnection` and returns a `Future`.
     pub async fn add_post_commit_async<F, Fut>(&mut self, mut f: F)
     where
-        F: FnMut(Connection) -> Fut,
+        F: FnMut(MultiplexedConnection) -> Fut,
         Fut: Future<Output = errs::Result<()>> + Send + 'static,
     {
-        match self.pool.get().await {
-            Ok(pooled_conn) => {
-                let fut = f(pooled_conn);
-                self.post_commit_vec.push(Box::pin(fut))
-            }
-            Err(e) => self.post_commit_vec.push(Box::pin(async move {
-                Err(errs::Err::with_source(
-                    RedisSentinelAsyncError::FailToGetConnectionFromPool,
-                    e,
-                ))
-            })),
-        }
+        let fut = f(self.conn.clone());
+        self.post_commit_vec.push(Box::pin(fut))
     }
 
     /// Adds an asynchronous function to be executed when a rollback occurs.
     ///
     /// # Arguments
-    /// * `f` - An async closure or function that takes a `Connection` and returns a `Future`.
+    /// * `f` - An async closure or function that takes a `MultiplexedConnection` and returns a `Future`.
     pub async fn add_force_back_async<F, Fut>(&mut self, mut f: F)
     where
-        F: FnMut(Connection) -> Fut,
+        F: FnMut(MultiplexedConnection) -> Fut,
         Fut: Future<Output = errs::Result<()>> + Send + 'static,
     {
-        match self.pool.get().await {
-            Ok(pooled_conn) => {
-                let fut = f(pooled_conn);
-                self.force_back_vec.push(Box::pin(fut))
-            }
-            Err(e) => self.force_back_vec.push(Box::pin(async move {
-                Err(errs::Err::with_source(
-                    RedisSentinelAsyncError::FailToGetConnectionFromPool,
-                    e,
-                ))
-            })),
-        }
+        let fut = f(self.conn.clone());
+        self.force_back_vec.push(Box::pin(fut))
     }
 }
 
@@ -332,7 +282,13 @@ impl DataSrc<RedisSentinelAsyncDataConn> for RedisSentinelAsyncDataSrc {
             .as_mut()
             .ok_or_else(|| errs::Err::new(RedisSentinelAsyncError::NotSetupYet))?;
         match pool {
-            RedisPool::Object(pool) => Ok(Box::new(RedisSentinelAsyncDataConn::new(pool.clone()))),
+            RedisPool::Object(pool) => match pool.get().await {
+                Ok(conn) => Ok(Box::new(RedisSentinelAsyncDataConn::new(conn))),
+                Err(e) => Err(errs::Err::with_source(
+                    RedisSentinelAsyncError::FailToGetConnectionFromPool,
+                    e,
+                )),
+            },
             _ => Err(errs::Err::new(RedisSentinelAsyncError::NotSetupYet)),
         }
     }
@@ -360,7 +316,7 @@ mod unit_tests {
             let data_conn = self
                 .get_data_conn_async::<RedisSentinelAsyncDataConn>("redis")
                 .await?;
-            let mut conn = data_conn.get_connection_async().await?;
+            let conn = data_conn.get_connection();
             conn.get("sample_sentinel_async")
                 .await
                 .map_err(|e| errs::Err::with_source(SampleSentinelAsyncError::FailToGetValue, e))
@@ -369,9 +325,7 @@ mod unit_tests {
             let data_conn = self
                 .get_data_conn_async::<RedisSentinelAsyncDataConn>("redis")
                 .await?;
-            let mut conn = data_conn
-                .get_connection_with_timeout_async(Timeouts::wait_millis(1000))
-                .await?;
+            let conn = data_conn.get_connection();
             conn.set("sample_sentinel_async", val)
                 .await
                 .map_err(|e| errs::Err::with_source(SampleSentinelAsyncError::FailToSetValue, e))
@@ -380,7 +334,7 @@ mod unit_tests {
             let data_conn = self
                 .get_data_conn_async::<RedisSentinelAsyncDataConn>("redis")
                 .await?;
-            let mut conn = data_conn.get_connection_async().await?;
+            let conn = data_conn.get_connection();
             conn.del("sample_sentinel_async")
                 .await
                 .map_err(|e| errs::Err::with_source(SampleSentinelAsyncError::FailToDelValue, e))
@@ -390,13 +344,14 @@ mod unit_tests {
             let data_conn = self
                 .get_data_conn_async::<RedisSentinelAsyncDataConn>("redis")
                 .await?;
-            let mut conn = data_conn
-                .get_connection_with_timeout_async(Timeouts::wait_millis(1000))
-                .await?;
-
-            conn.set::<&str, &str, ()>("sample_force_back_sentinel_async", val)
-                .await
-                .map_err(|e| errs::Err::with_source(SampleSentinelAsyncError::FailToSetValue, e))?;
+            {
+                let conn = data_conn.get_connection();
+                conn.set::<&str, &str, ()>("sample_force_back_sentinel_async", val)
+                    .await
+                    .map_err(|e| {
+                        errs::Err::with_source(SampleSentinelAsyncError::FailToSetValue, e)
+                    })?;
+            }
 
             data_conn
                 .add_force_back_async(async |mut conn| {
@@ -406,9 +361,14 @@ mod unit_tests {
                 })
                 .await;
 
-            conn.set::<&str, &str, ()>("sample_force_back_sentinel_async_2", val)
-                .await
-                .map_err(|e| errs::Err::with_source(SampleSentinelAsyncError::FailToSetValue, e))?;
+            {
+                let conn = data_conn.get_connection();
+                conn.set::<&str, &str, ()>("sample_force_back_sentinel_async_2", val)
+                    .await
+                    .map_err(|e| {
+                        errs::Err::with_source(SampleSentinelAsyncError::FailToSetValue, e)
+                    })?;
+            }
 
             data_conn
                 .add_force_back_async(async |mut conn| {

--- a/src/sentinel_sync.rs
+++ b/src/sentinel_sync.rs
@@ -11,7 +11,7 @@ use redis::{Connection, IntoConnectionInfo};
 use sabi::{AsyncGroup, DataConn, DataSrc};
 
 use std::fmt::Debug;
-use std::{mem, time};
+use std::mem;
 
 /// The error type for synchronous Redis Sentinel operations.
 #[derive(Debug)]
@@ -35,7 +35,7 @@ pub enum RedisSentinelSyncError {
 #[allow(clippy::type_complexity)]
 /// A data connection for Redis Sentinel, providing synchronous operations.
 ///
-/// This structure holds a connection pool for a Redis Sentinel-managed setup
+/// This structure holds a pooled connection for a Redis Sentinel-managed setup
 /// and allows for adding hooks (pre-commit, post-commit, and force-back)
 /// that are executed during the lifecycle of a data operation managed by `sabi`.
 ///
@@ -48,22 +48,22 @@ pub enum RedisSentinelSyncError {
 /// trait MyDataAcc: DataAcc {
 ///     fn set_value(&mut self, key: &str, val: &str) -> errs::Result<()> {
 ///         let data_conn = self.get_data_conn::<RedisSentinelDataConn>("redis")?;
-///         let mut conn = data_conn.get_connection()?;
+///         let conn = data_conn.get_connection();
 ///         conn.set(key, val).map_err(|e| errs::Err::with_source("fail", e))
 ///     }
 /// }
 /// ```
 pub struct RedisSentinelDataConn {
-    pool: Pool<LockedSentinelClient>,
+    conn: PooledConnection<LockedSentinelClient>,
     pre_commit_vec: Vec<Box<dyn FnMut(&mut Connection) -> errs::Result<()>>>,
     post_commit_vec: Vec<Box<dyn FnMut(&mut Connection) -> errs::Result<()>>>,
     force_back_vec: Vec<Box<dyn FnMut(&mut Connection) -> errs::Result<()>>>,
 }
 
 impl RedisSentinelDataConn {
-    fn new(pool: Pool<LockedSentinelClient>) -> Self {
+    fn new(conn: PooledConnection<LockedSentinelClient>) -> Self {
         Self {
-            pool,
+            conn,
             pre_commit_vec: Vec::new(),
             post_commit_vec: Vec::new(),
             force_back_vec: Vec::new(),
@@ -73,37 +73,9 @@ impl RedisSentinelDataConn {
     /// Gets a Sentinel-managed connection from the pool.
     ///
     /// # Returns
-    /// Returns a `Result` containing a `PooledConnection<LockedSentinelClient>` on success,
-    /// or a `RedisSentinelSyncError::FailToGetConnectionFromPool` wrapped in `errs::Err` on failure.
-    pub fn get_connection(&mut self) -> errs::Result<PooledConnection<LockedSentinelClient>> {
-        self.pool.get().map_err(|e| {
-            errs::Err::with_source(RedisSentinelSyncError::FailToGetConnectionFromPool, e)
-        })
-    }
-
-    /// Gets a Sentinel-managed connection from the pool with a specific timeout.
-    ///
-    /// # Arguments
-    /// * `timeout` - A `Duration` to wait for a connection before failing.
-    ///
-    /// # Returns
-    /// Returns a `Result` containing a `PooledConnection<LockedSentinelClient>` on success,
-    /// or a `RedisSentinelSyncError::FailToGetConnectionFromPool` wrapped in `errs::Err` on failure.
-    pub fn get_connection_with_timeout(
-        &mut self,
-        timeout: time::Duration,
-    ) -> errs::Result<PooledConnection<LockedSentinelClient>> {
-        self.pool.get_timeout(timeout).map_err(|e| {
-            errs::Err::with_source(RedisSentinelSyncError::FailToGetConnectionFromPool, e)
-        })
-    }
-
-    /// Tries to get a Sentinel-managed connection from the pool immediately without waiting.
-    ///
-    /// # Returns
-    /// Returns `Some(PooledConnection<LockedSentinelClient>)` if a connection is available, otherwise `None`.
-    pub fn try_get_connection(&self) -> Option<PooledConnection<LockedSentinelClient>> {
-        self.pool.try_get()
+    /// Returns a mutable reference to a `PooledConnection<LockedSentinelClient>`.
+    pub fn get_connection(&mut self) -> &mut PooledConnection<LockedSentinelClient> {
+        &mut self.conn
     }
 
     /// Adds a function to be executed before a commit occurs in the `sabi` lifecycle.
@@ -142,18 +114,10 @@ impl RedisSentinelDataConn {
 
 impl DataConn for RedisSentinelDataConn {
     fn pre_commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
-        match self.pool.get() {
-            Ok(mut conn) => {
-                for f in self.pre_commit_vec.iter_mut() {
-                    f(&mut conn)?;
-                }
-                Ok(())
-            }
-            Err(e) => Err(errs::Err::with_source(
-                RedisSentinelSyncError::FailToGetConnectionFromPool,
-                e,
-            )),
+        for f in self.pre_commit_vec.iter_mut() {
+            f(&mut self.conn)?;
         }
+        Ok(())
     }
 
     fn commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
@@ -161,19 +125,10 @@ impl DataConn for RedisSentinelDataConn {
     }
 
     fn post_commit(&mut self, _ag: &mut AsyncGroup) {
-        match self.pool.get() {
-            Ok(mut conn) => {
-                for f in self.post_commit_vec.iter_mut() {
-                    // for error notification
-                    let _ = f(&mut conn);
-                }
-            }
-            Err(e) => {
-                // for error notification
-                let _ =
-                    errs::Err::with_source(RedisSentinelSyncError::FailToGetConnectionFromPool, e);
-            }
-        };
+        for f in self.post_commit_vec.iter_mut() {
+            // for error notification
+            let _ = f(&mut self.conn);
+        }
     }
 
     fn rollback(&mut self, _ag: &mut AsyncGroup) {}
@@ -183,19 +138,10 @@ impl DataConn for RedisSentinelDataConn {
     }
 
     fn force_back(&mut self, _ag: &mut AsyncGroup) {
-        match self.pool.get() {
-            Ok(mut conn) => {
-                for f in self.force_back_vec.iter_mut().rev() {
-                    // for error notification
-                    let _ = f(&mut conn);
-                }
-            }
-            Err(e) => {
-                // for error notification
-                let _ =
-                    errs::Err::with_source(RedisSentinelSyncError::FailToGetConnectionFromPool, e);
-            }
-        };
+        for f in self.force_back_vec.iter_mut().rev() {
+            // for error notification
+            let _ = f(&mut self.conn);
+        }
     }
 
     fn close(&mut self) {}
@@ -428,7 +374,13 @@ where
             .as_mut()
             .ok_or_else(|| errs::Err::new(RedisSentinelSyncError::NotSetupYet))?;
         match pool {
-            RedisPool::Object(pool) => Ok(Box::new(RedisSentinelDataConn::new(pool.clone()))),
+            RedisPool::Object(pool) => match pool.get() {
+                Ok(conn) => Ok(Box::new(RedisSentinelDataConn::new(conn))),
+                Err(e) => Err(errs::Err::with_source(
+                    RedisSentinelSyncError::FailToGetConnectionFromPool,
+                    e,
+                )),
+            },
             _ => Err(errs::Err::new(RedisSentinelSyncError::NotSetupYet)),
         }
     }
@@ -454,38 +406,42 @@ mod unit_tests {
     trait RedisSentinelSampleDataAcc: DataAcc {
         fn get_sample_key(&mut self) -> errs::Result<Option<String>> {
             let data_conn = self.get_data_conn::<RedisSentinelDataConn>("redis")?;
-            let mut conn = data_conn.get_connection()?;
+            let conn = data_conn.get_connection();
             conn.get("sample_sentinel")
                 .map_err(|e| errs::Err::with_source(SampleError::FailToGetValue, e))
         }
         fn set_sample_key(&mut self, val: &str) -> errs::Result<()> {
             let data_conn = self.get_data_conn::<RedisSentinelDataConn>("redis")?;
-            let mut conn =
-                data_conn.get_connection_with_timeout(time::Duration::from_millis(1000))?;
+            let conn = data_conn.get_connection();
             conn.set("sample_sentinel", val)
                 .map_err(|e| errs::Err::with_source(SampleError::FailToGetValue, e))
         }
         fn del_sample_key(&mut self) -> errs::Result<()> {
             let data_conn = self.get_data_conn::<RedisSentinelDataConn>("redis")?;
-            let mut conn = data_conn.try_get_connection().unwrap();
+            let conn = data_conn.get_connection();
             conn.del("sample_sentinel")
                 .map_err(|e| errs::Err::with_source(SampleError::FailToDelValue, e))
         }
 
         fn set_sample_key_with_force_back(&mut self, val: &str) -> errs::Result<()> {
             let data_conn = self.get_data_conn::<RedisSentinelDataConn>("redis")?;
-            let mut conn = data_conn.get_connection()?;
 
-            conn.set::<&str, &str, ()>("sample_force_back_sentinel", val)
-                .map_err(|e| errs::Err::with_source(SampleError::FailToSetValue, e))?;
+            {
+                let conn = data_conn.get_connection();
+                conn.set::<&str, &str, ()>("sample_force_back_sentinel", val)
+                    .map_err(|e| errs::Err::with_source(SampleError::FailToSetValue, e))?;
+            }
 
             data_conn.add_force_back(|conn| {
                 conn.del("sample_force_back_sentinel")
                     .map_err(|e| errs::Err::with_source("fail to force back", e))
             });
 
-            conn.set::<&str, &str, ()>("sample_force_back_sentinel_2", val)
-                .map_err(|e| errs::Err::with_source(SampleError::FailToSetValue, e))?;
+            {
+                let conn = data_conn.get_connection();
+                conn.set::<&str, &str, ()>("sample_force_back_sentinel_2", val)
+                    .map_err(|e| errs::Err::with_source(SampleError::FailToSetValue, e))?;
+            }
 
             data_conn.add_force_back(|conn| {
                 conn.del("sample_force_back_sentinel_2")

--- a/src/standalone_async.rs
+++ b/src/standalone_async.rs
@@ -2,8 +2,8 @@
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
-use deadpool_redis::Timeouts;
 use deadpool_redis::{Config, Connection, Pool, PoolConfig, Runtime};
+use redis::aio::MultiplexedConnection;
 use sabi::tokio::{AsyncGroup, DataConn, DataSrc};
 
 use std::future::Future;
@@ -39,125 +39,73 @@ type BoxedFuture = pin::Pin<Box<dyn Future<Output = errs::Result<()>> + Send + '
 /// trait MyDataAcc: DataAcc {
 ///     async fn set_value(&mut self, key: &str, val: &str) -> errs::Result<()> {
 ///         let data_conn = self.get_data_conn_async::<RedisAsyncDataConn>("redis").await?;
-///         let mut conn = data_conn.get_connection_async().await?;
+///         let conn = data_conn.get_connection();
 ///         conn.set(key, val).await.map_err(|e| errs::Err::with_source("fail", e))
 ///     }
 /// }
 /// ```
 pub struct RedisAsyncDataConn {
-    pool: Pool,
+    conn: Connection,
     pre_commit_vec: Vec<BoxedFuture>,
     post_commit_vec: Vec<BoxedFuture>,
     force_back_vec: Vec<BoxedFuture>,
 }
 
 impl RedisAsyncDataConn {
-    fn new(pool: Pool) -> Self {
+    fn new(conn: Connection) -> Self {
         Self {
-            pool,
+            conn,
             pre_commit_vec: Vec::new(),
             post_commit_vec: Vec::new(),
             force_back_vec: Vec::new(),
         }
     }
 
-    /// Gets an asynchronous connection from the pool.
+    /// Gets an asynchronous connection.
     ///
     /// # Returns
-    /// Returns a `Result` containing a `Connection` on success,
-    /// or a `RedisAsyncError::FailToGetConnectionFromPool` wrapped in `errs::Err` on failure.
-    pub async fn get_connection_async(&mut self) -> errs::Result<Connection> {
-        self.pool
-            .get()
-            .await
-            .map_err(|e| errs::Err::with_source(RedisAsyncError::FailToGetConnectionFromPool, e))
-    }
-
-    /// Gets an asynchronous connection from the pool with specific timeouts.
-    ///
-    /// # Arguments
-    /// * `timeouts` - A `Timeouts` configuration for getting a connection.
-    ///
-    /// # Returns
-    /// Returns a `Result` containing a `Connection` on success,
-    /// or a `RedisAsyncError::FailToGetConnectionFromPool` wrapped in `errs::Err` on failure.
-    pub async fn get_connection_with_timeout_async(
-        &mut self,
-        timeouts: Timeouts,
-    ) -> errs::Result<Connection> {
-        self.pool
-            .timeout_get(&timeouts)
-            .await
-            .map_err(|e| errs::Err::with_source(RedisAsyncError::FailToGetConnectionFromPool, e))
+    /// Returns a mutable reference to a `MultiplexedConnection`.
+    pub fn get_connection(&mut self) -> &mut MultiplexedConnection {
+        &mut self.conn
     }
 
     /// Adds an asynchronous function to be executed before a commit occurs.
     ///
     /// # Arguments
-    /// * `f` - An async closure or function that takes a `Connection` and returns a `Future`.
+    /// * `f` - An async closure or function that takes a `MultiplexedConnection` and returns a `Future`.
     pub async fn add_pre_commit_async<F, Fut>(&mut self, mut f: F)
     where
-        F: FnMut(Connection) -> Fut,
+        F: FnMut(MultiplexedConnection) -> Fut,
         Fut: Future<Output = errs::Result<()>> + Send + 'static,
     {
-        match self.pool.get().await {
-            Ok(pooled_conn) => {
-                let fut = f(pooled_conn);
-                self.pre_commit_vec.push(Box::pin(fut))
-            }
-            Err(e) => self.pre_commit_vec.push(Box::pin(async move {
-                Err(errs::Err::with_source(
-                    RedisAsyncError::FailToGetConnectionFromPool,
-                    e,
-                ))
-            })),
-        }
+        let fut = f(self.conn.clone());
+        self.pre_commit_vec.push(Box::pin(fut))
     }
 
     /// Adds an asynchronous function to be executed after a successful commit.
     ///
     /// # Arguments
-    /// * `f` - An async closure or function that takes a `Connection` and returns a `Future`.
+    /// * `f` - An async closure or function that takes a `MultiplexedConnection` and returns a `Future`.
     pub async fn add_post_commit_async<F, Fut>(&mut self, mut f: F)
     where
-        F: FnMut(Connection) -> Fut,
+        F: FnMut(MultiplexedConnection) -> Fut,
         Fut: Future<Output = errs::Result<()>> + Send + 'static,
     {
-        match self.pool.get().await {
-            Ok(pooled_conn) => {
-                let fut = f(pooled_conn);
-                self.post_commit_vec.push(Box::pin(fut))
-            }
-            Err(e) => self.post_commit_vec.push(Box::pin(async move {
-                Err(errs::Err::with_source(
-                    RedisAsyncError::FailToGetConnectionFromPool,
-                    e,
-                ))
-            })),
-        }
+        let fut = f(self.conn.clone());
+        self.post_commit_vec.push(Box::pin(fut))
     }
 
     /// Adds an asynchronous function to be executed when a rollback occurs.
     ///
     /// # Arguments
-    /// * `f` - An async closure or function that takes a `Connection` and returns a `Future`.
+    /// * `f` - An async closure or function that takes a `MultiplexedConnection` and returns a `Future`.
     pub async fn add_force_back_async<F, Fut>(&mut self, mut f: F)
     where
-        F: FnMut(Connection) -> Fut,
+        F: FnMut(MultiplexedConnection) -> Fut,
         Fut: Future<Output = errs::Result<()>> + Send + 'static,
     {
-        match self.pool.get().await {
-            Ok(pooled_conn) => {
-                let fut = f(pooled_conn);
-                self.force_back_vec.push(Box::pin(fut))
-            }
-            Err(e) => self.force_back_vec.push(Box::pin(async move {
-                Err(errs::Err::with_source(
-                    RedisAsyncError::FailToGetConnectionFromPool,
-                    e,
-                ))
-            })),
-        }
+        let fut = f(self.conn.clone());
+        self.force_back_vec.push(Box::pin(fut))
     }
 }
 
@@ -309,7 +257,13 @@ impl DataSrc<RedisAsyncDataConn> for RedisAsyncDataSrc {
             .as_mut()
             .ok_or_else(|| errs::Err::new(RedisAsyncError::NotSetupYet))?;
         match pool {
-            RedisPool::Object(pool) => Ok(Box::new(RedisAsyncDataConn::new(pool.clone()))),
+            RedisPool::Object(pool) => match pool.get().await {
+                Ok(conn) => Ok(Box::new(RedisAsyncDataConn::new(conn))),
+                Err(e) => Err(errs::Err::with_source(
+                    RedisAsyncError::FailToGetConnectionFromPool,
+                    e,
+                )),
+            },
             _ => Err(errs::Err::new(RedisAsyncError::NotSetupYet)),
         }
     }
@@ -337,7 +291,7 @@ mod unit_tests {
             let data_conn = self
                 .get_data_conn_async::<RedisAsyncDataConn>("redis")
                 .await?;
-            let mut conn = data_conn.get_connection_async().await?;
+            let conn = data_conn.get_connection();
             conn.get("sample_async")
                 .await
                 .map_err(|e| errs::Err::with_source(SampleAsyncError::FailToGetValue, e))
@@ -346,9 +300,7 @@ mod unit_tests {
             let data_conn = self
                 .get_data_conn_async::<RedisAsyncDataConn>("redis")
                 .await?;
-            let mut conn = data_conn
-                .get_connection_with_timeout_async(Timeouts::wait_millis(1000))
-                .await?;
+            let conn = data_conn.get_connection();
             conn.set("sample_async", val)
                 .await
                 .map_err(|e| errs::Err::with_source(SampleAsyncError::FailToSetValue, e))
@@ -357,7 +309,7 @@ mod unit_tests {
             let data_conn = self
                 .get_data_conn_async::<RedisAsyncDataConn>("redis")
                 .await?;
-            let mut conn = data_conn.get_connection_async().await?;
+            let conn = data_conn.get_connection();
             conn.del("sample_async")
                 .await
                 .map_err(|e| errs::Err::with_source(SampleAsyncError::FailToDelValue, e))
@@ -367,13 +319,12 @@ mod unit_tests {
             let data_conn = self
                 .get_data_conn_async::<RedisAsyncDataConn>("redis")
                 .await?;
-            let mut conn = data_conn
-                .get_connection_with_timeout_async(Timeouts::wait_millis(1000))
-                .await?;
-
-            conn.set::<&str, &str, ()>("sample_force_back_async", val)
-                .await
-                .map_err(|e| errs::Err::with_source(SampleAsyncError::FailToSetValue, e))?;
+            {
+                let conn = data_conn.get_connection();
+                conn.set::<&str, &str, ()>("sample_force_back_async", val)
+                    .await
+                    .map_err(|e| errs::Err::with_source(SampleAsyncError::FailToSetValue, e))?;
+            }
 
             data_conn
                 .add_force_back_async(async |mut conn| {
@@ -383,9 +334,12 @@ mod unit_tests {
                 })
                 .await;
 
-            conn.set::<&str, &str, ()>("sample_force_back_async_2", val)
-                .await
-                .map_err(|e| errs::Err::with_source(SampleAsyncError::FailToSetValue, e))?;
+            {
+                let conn = data_conn.get_connection();
+                conn.set::<&str, &str, ()>("sample_force_back_async_2", val)
+                    .await
+                    .map_err(|e| errs::Err::with_source(SampleAsyncError::FailToSetValue, e))?;
+            }
 
             data_conn
                 .add_force_back_async(async |mut conn| {

--- a/src/standalone_sync.rs
+++ b/src/standalone_sync.rs
@@ -7,7 +7,7 @@ use redis::{Client, Connection, IntoConnectionInfo};
 use sabi::{AsyncGroup, DataConn, DataSrc};
 
 use std::fmt::Debug;
-use std::{mem, time};
+use std::mem;
 
 /// The error type for synchronous Redis operations.
 #[derive(Debug)]
@@ -27,7 +27,7 @@ pub enum RedisSyncError {
 #[allow(clippy::type_complexity)]
 /// A data connection for a standalone Redis server, providing synchronous operations.
 ///
-/// This structure holds a connection pool and allows for adding hooks (pre-commit, post-commit,
+/// This structure holds a pooled connection and allows for adding hooks (pre-commit, post-commit,
 /// and force-back) that are executed during the lifecycle of a data operation managed by `sabi`.
 ///
 /// # Examples
@@ -39,22 +39,22 @@ pub enum RedisSyncError {
 /// trait MyDataAcc: DataAcc {
 ///     fn set_value(&mut self, key: &str, val: &str) -> errs::Result<()> {
 ///         let data_conn = self.get_data_conn::<RedisDataConn>("redis")?;
-///         let mut conn = data_conn.get_connection()?;
+///         let conn = data_conn.get_connection();
 ///         conn.set(key, val).map_err(|e| errs::Err::with_source("fail", e))
 ///     }
 /// }
 /// ```
 pub struct RedisDataConn {
-    pool: Pool<Client>,
+    conn: PooledConnection<Client>,
     pre_commit_vec: Vec<Box<dyn FnMut(&mut Connection) -> errs::Result<()>>>,
     post_commit_vec: Vec<Box<dyn FnMut(&mut Connection) -> errs::Result<()>>>,
     force_back_vec: Vec<Box<dyn FnMut(&mut Connection) -> errs::Result<()>>>,
 }
 
 impl RedisDataConn {
-    fn new(pool: Pool<Client>) -> Self {
+    fn new(conn: PooledConnection<Client>) -> Self {
         Self {
-            pool,
+            conn,
             pre_commit_vec: Vec::new(),
             post_commit_vec: Vec::new(),
             force_back_vec: Vec::new(),
@@ -64,37 +64,9 @@ impl RedisDataConn {
     /// Gets a connection from the pool.
     ///
     /// # Returns
-    /// Returns a `Result` containing a `PooledConnection<Client>` on success,
-    /// or a `RedisSyncError::FailToGetConnectionFromPool` wrapped in `errs::Err` on failure.
-    pub fn get_connection(&mut self) -> errs::Result<PooledConnection<Client>> {
-        self.pool
-            .get()
-            .map_err(|e| errs::Err::with_source(RedisSyncError::FailToGetConnectionFromPool, e))
-    }
-
-    /// Gets a connection from the pool with a specific timeout.
-    ///
-    /// # Arguments
-    /// * `timeout` - A `Duration` to wait for a connection before failing.
-    ///
-    /// # Returns
-    /// Returns a `Result` containing a `PooledConnection<Client>` on success,
-    /// or a `RedisSyncError::FailToGetConnectionFromPool` wrapped in `errs::Err` on failure.
-    pub fn get_connection_with_timeout(
-        &self,
-        timeout: time::Duration,
-    ) -> errs::Result<PooledConnection<Client>> {
-        self.pool
-            .get_timeout(timeout)
-            .map_err(|e| errs::Err::with_source(RedisSyncError::FailToGetConnectionFromPool, e))
-    }
-
-    /// Tries to get a connection from the pool immediately without waiting.
-    ///
-    /// # Returns
-    /// Returns `Some(PooledConnection<Client>)` if a connection is available, otherwise `None`.
-    pub fn try_get_connection(&self) -> Option<PooledConnection<Client>> {
-        self.pool.try_get()
+    /// Returns a mutable reference to a `Connection`.
+    pub fn get_connection(&mut self) -> &mut Connection {
+        &mut self.conn
     }
 
     /// Adds a function to be executed before a commit occurs in the `sabi` lifecycle.
@@ -133,18 +105,10 @@ impl RedisDataConn {
 
 impl DataConn for RedisDataConn {
     fn pre_commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
-        match self.pool.get() {
-            Ok(mut conn) => {
-                for f in self.pre_commit_vec.iter_mut() {
-                    f(&mut conn)?;
-                }
-                Ok(())
-            }
-            Err(e) => Err(errs::Err::with_source(
-                RedisSyncError::FailToGetConnectionFromPool,
-                e,
-            )),
+        for f in self.pre_commit_vec.iter_mut() {
+            f(&mut self.conn)?;
         }
+        Ok(())
     }
 
     fn commit(&mut self, _ag: &mut AsyncGroup) -> errs::Result<()> {
@@ -152,18 +116,10 @@ impl DataConn for RedisDataConn {
     }
 
     fn post_commit(&mut self, _ag: &mut AsyncGroup) {
-        match self.pool.get() {
-            Ok(mut conn) => {
-                for f in self.post_commit_vec.iter_mut() {
-                    // for error notification
-                    let _ = f(&mut conn);
-                }
-            }
-            Err(e) => {
-                // for error notification
-                let _ = errs::Err::with_source(RedisSyncError::FailToGetConnectionFromPool, e);
-            }
-        };
+        for f in self.post_commit_vec.iter_mut() {
+            // for error notification
+            let _ = f(&mut self.conn);
+        }
     }
 
     fn rollback(&mut self, _ag: &mut AsyncGroup) {}
@@ -173,18 +129,10 @@ impl DataConn for RedisDataConn {
     }
 
     fn force_back(&mut self, _ag: &mut AsyncGroup) {
-        match self.pool.get() {
-            Ok(mut conn) => {
-                for f in self.force_back_vec.iter_mut().rev() {
-                    // for error notification
-                    let _ = f(&mut conn);
-                }
-            }
-            Err(e) => {
-                // for error notification
-                let _ = errs::Err::with_source(RedisSyncError::FailToGetConnectionFromPool, e);
-            }
-        };
+        for f in self.force_back_vec.iter_mut().rev() {
+            // for error notification
+            let _ = f(&mut self.conn);
+        }
     }
 
     fn close(&mut self) {}
@@ -283,7 +231,13 @@ where
             .as_mut()
             .ok_or_else(|| errs::Err::new(RedisSyncError::NotSetupYet))?;
         match pool {
-            RedisPool::Object(pool) => Ok(Box::new(RedisDataConn::new(pool.clone()))),
+            RedisPool::Object(pool) => match pool.get() {
+                Ok(conn) => Ok(Box::new(RedisDataConn::new(conn))),
+                Err(e) => Err(errs::Err::with_source(
+                    RedisSyncError::FailToGetConnectionFromPool,
+                    e,
+                )),
+            },
             _ => Err(errs::Err::new(RedisSyncError::NotSetupYet)),
         }
     }
@@ -308,38 +262,42 @@ mod unit_tests {
     trait RedisSampleDataAcc: DataAcc {
         fn get_sample_key(&mut self) -> errs::Result<Option<String>> {
             let data_conn = self.get_data_conn::<RedisDataConn>("redis")?;
-            let mut conn = data_conn.get_connection()?;
+            let conn = data_conn.get_connection();
             conn.get("sample")
                 .map_err(|e| errs::Err::with_source(SampleError::FailToGetValue, e))
         }
         fn set_sample_key(&mut self, val: &str) -> errs::Result<()> {
             let data_conn = self.get_data_conn::<RedisDataConn>("redis")?;
-            let mut conn =
-                data_conn.get_connection_with_timeout(time::Duration::from_millis(1000))?;
+            let conn = data_conn.get_connection();
             conn.set("sample", val)
                 .map_err(|e| errs::Err::with_source(SampleError::FailToSetValue, e))
         }
         fn del_sample_key(&mut self) -> errs::Result<()> {
             let data_conn = self.get_data_conn::<RedisDataConn>("redis")?;
-            let mut conn = data_conn.try_get_connection().unwrap();
+            let conn = data_conn.get_connection();
             conn.del("sample")
                 .map_err(|e| errs::Err::with_source(SampleError::FailToDelValue, e))
         }
 
         fn set_sample_key_with_force_back(&mut self, val: &str) -> errs::Result<()> {
             let data_conn = self.get_data_conn::<RedisDataConn>("redis")?;
-            let mut conn = data_conn.get_connection()?;
 
-            conn.set::<&str, &str, ()>("sample_force_back", val)
-                .map_err(|e| errs::Err::with_source(SampleError::FailToSetValue, e))?;
+            {
+                let conn = data_conn.get_connection();
+                conn.set::<&str, &str, ()>("sample_force_back", val)
+                    .map_err(|e| errs::Err::with_source(SampleError::FailToSetValue, e))?;
+            }
 
             data_conn.add_force_back(|conn| {
                 conn.del("sample_force_back")
                     .map_err(|e| errs::Err::with_source("fail to force back", e))
             });
 
-            conn.set::<&str, &str, ()>("sample_force_back_2", val)
-                .map_err(|e| errs::Err::with_source(SampleError::FailToSetValue, e))?;
+            {
+                let conn = data_conn.get_connection();
+                conn.set::<&str, &str, ()>("sample_force_back_2", val)
+                    .map_err(|e| errs::Err::with_source(SampleError::FailToSetValue, e))?;
+            }
 
             data_conn.add_force_back(|conn| {
                 conn.del("sample_force_back_2")

--- a/tests/cluster_async_test.rs
+++ b/tests/cluster_async_test.rs
@@ -50,7 +50,7 @@ mod integration_tests {
             let data_conn = self
                 .get_data_conn_async::<RedisClusterAsyncDataConn>("redis_cluster")
                 .await?;
-            let mut redis_conn = data_conn.get_connection_async().await?;
+            let redis_conn = data_conn.get_connection();
 
             redis_conn
                 .set::<_, _, ()>("greeting", greeting)

--- a/tests/cluster_sync_test.rs
+++ b/tests/cluster_sync_test.rs
@@ -49,7 +49,7 @@ mod integration_tests {
     trait RedisSayingDataAcc: DataAcc {
         fn say_greeting(&mut self, greeting: &str) -> errs::Result<()> {
             let data_conn = self.get_data_conn::<RedisClusterDataConn>("redis_cluster")?;
-            let mut redis_conn = data_conn.get_connection()?;
+            let redis_conn = data_conn.get_connection();
 
             if let Err(e) = redis_conn.set("greeting", greeting) {
                 return Err(errs::Err::with_source("fail to set greeting", e));

--- a/tests/sentinel_async_test.rs
+++ b/tests/sentinel_async_test.rs
@@ -56,7 +56,7 @@ mod integration_tests {
             let data_conn = self
                 .get_data_conn_async::<RedisSentinelAsyncDataConn>("redis_sentinel")
                 .await?;
-            let mut redis_conn = data_conn.get_connection_async().await?;
+            let redis_conn = data_conn.get_connection();
 
             redis_conn
                 .set::<_, _, ()>("greeting", greeting)

--- a/tests/sentinel_sync_test.rs
+++ b/tests/sentinel_sync_test.rs
@@ -52,7 +52,7 @@ mod integration_tests {
     trait RedisSayingDataAcc: DataAcc {
         fn say_greeting(&mut self, greeting: &str) -> errs::Result<()> {
             let data_conn = self.get_data_conn::<RedisSentinelDataConn>("redis_sentinel")?;
-            let mut redis_conn = data_conn.get_connection()?;
+            let redis_conn = data_conn.get_connection();
 
             if let Err(e) = redis_conn.set("greeting", greeting) {
                 return Err(errs::Err::with_source("fail to set greeting", e));

--- a/tests/standalone_async_test.rs
+++ b/tests/standalone_async_test.rs
@@ -43,7 +43,7 @@ mod integration_tests {
             let data_conn = self
                 .get_data_conn_async::<RedisAsyncDataConn>("redis")
                 .await?;
-            let mut redis_conn = data_conn.get_connection_async().await?;
+            let redis_conn = data_conn.get_connection();
 
             redis_conn
                 .set::<_, _, ()>("greeting", greeting)

--- a/tests/standalone_sync_test.rs
+++ b/tests/standalone_sync_test.rs
@@ -42,7 +42,7 @@ mod integration_tests {
     trait RedisSayingDataAcc: DataAcc {
         fn say_greeting(&mut self, greeting: &str) -> errs::Result<()> {
             let data_conn = self.get_data_conn::<RedisDataConn>("redis")?;
-            let mut redis_conn = data_conn.get_connection()?;
+            let redis_conn = data_conn.get_connection();
 
             if let Err(e) = redis_conn.set("greeting", greeting) {
                 return Err(errs::Err::with_source("fail to set greeting", e));


### PR DESCRIPTION
This PR changes the internal implementation of `DataConn` across all configurations (Standalone, Sentinel, and Cluster) for both synchronous and asynchronous modes. `DataConn` now directly holds a single `Connection` acquired at the start of a transaction, rather than holding a `Pool`.

This change makes it possible to keep Redis sessions through `DataHub::txn` or `DataHub::run` and utilize commands:`MULTI`, `EXEC`, `WATCH`, and so on.