### PR TITLE
doc,comment: added documentation comments to the items in standalone_tokio module

### DIFF
--- a/src/standalone_tokio/mod.rs
+++ b/src/standalone_tokio/mod.rs
@@ -12,17 +12,30 @@ use sabi::tokio::{AsyncGroup, DataConn, DataSrc};
 use std::future::Future;
 use std::{mem, pin, time};
 
+/// Errors related to Redis data source and connection for asynchronous standalone environment.
 #[derive(Debug)]
 pub enum RedisErrorAsync {
+    /// Indicates that the data source is not yet setup.
     NotSetupYet,
+    /// Indicates that the data source is already setup.
     AlreadySetup,
-    FailToBuildPool { config: Config },
-    FailToConnect { config: Config },
+    /// Failed to build a Redis connection pool.
+    FailToBuildPool {
+        /// The Redis configuration.
+        config: Config,
+    },
+    /// Failed to connect to Redis.
+    FailToConnect {
+        /// The Redis configuration.
+        config: Config,
+    },
+    /// Failed to get a connection from the pool.
     FailToGetConnectionFromPool,
 }
 
 type BoxedFuture = pin::Pin<Box<dyn Future<Output = errs::Result<()>> + Send + 'static>>;
 
+/// A struct that holds a Redis connection and asynchronous transaction callbacks for standalone environment.
 pub struct RedisDataConnAsync {
     conn: Connection,
     pre_commit_vec: Vec<BoxedFuture>,
@@ -40,10 +53,20 @@ impl RedisDataConnAsync {
         }
     }
 
+    /// Returns a mutable reference to the underlying Redis multiplexed connection.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to the `redis::aio::MultiplexedConnection`.
     pub fn get_connection(&mut self) -> &mut MultiplexedConnection {
         &mut self.conn
     }
 
+    /// Adds an asynchronous callback function to be executed before a transaction is committed.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - A callback function that takes a `MultiplexedConnection` and returns a `Future`.
     pub async fn add_pre_commit_async<F, Fut>(&mut self, mut f: F)
     where
         F: FnMut(MultiplexedConnection) -> Fut,
@@ -53,6 +76,11 @@ impl RedisDataConnAsync {
         self.pre_commit_vec.push(Box::pin(fut))
     }
 
+    /// Adds an asynchronous callback function to be executed after a transaction is committed.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - A callback function that takes a `MultiplexedConnection` and returns a `Future`.
     pub async fn add_post_commit_async<F, Fut>(&mut self, mut f: F)
     where
         F: FnMut(MultiplexedConnection) -> Fut,
@@ -62,6 +90,11 @@ impl RedisDataConnAsync {
         self.post_commit_vec.push(Box::pin(fut))
     }
 
+    /// Adds an asynchronous callback function to be executed when a transaction is rolled back or forced back.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - A callback function that takes a `MultiplexedConnection` and returns a `Future`.
     pub async fn add_force_back_async<F, Fut>(&mut self, mut f: F)
     where
         F: FnMut(MultiplexedConnection) -> Fut,
@@ -116,6 +149,7 @@ impl DataConn for RedisDataConnAsync {
     }
 }
 
+/// A struct that manages an asynchronous Redis connection pool for standalone environment.
 pub struct RedisDataSrcAsync {
     pool: Option<RedisPool>,
 }
@@ -126,6 +160,15 @@ enum RedisPool {
 }
 
 impl RedisDataSrcAsync {
+    /// Creates a new `RedisDataSrcAsync` with a connection address string.
+    ///
+    /// # Arguments
+    ///
+    /// * `addr` - A string slice that holds the Redis connection address (e.g., "redis://127.0.0.1/").
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisDataSrcAsync`.
     pub fn new<S>(addr: S) -> Self
     where
         S: AsRef<str>,
@@ -139,6 +182,16 @@ impl RedisDataSrcAsync {
         }
     }
 
+    /// Creates a new `RedisDataSrcAsync` with a connection address and a custom pool configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `addr` - A string slice that holds the Redis connection address.
+    /// * `pool_config` - A `deadpool_redis::PoolConfig` for configuring the connection pool.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisDataSrcAsync`.
     pub fn with_pool_config<S>(addr: S, pool_config: PoolConfig) -> Self
     where
         S: AsRef<str>,
@@ -152,6 +205,15 @@ impl RedisDataSrcAsync {
         }
     }
 
+    /// Creates a new `RedisDataSrcAsync` with a `deadpool_redis::Config`.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - A `deadpool_redis::Config`.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisDataSrcAsync`.
     pub fn with_config(config: Config) -> Self {
         Self {
             pool: Some(RedisPool::Config(config)),

--- a/src/standalone_tokio/pubsub.rs
+++ b/src/standalone_tokio/pubsub.rs
@@ -8,18 +8,49 @@ use redis::aio::PubSub;
 use redis::{Client, ConnectionAddr, ConnectionInfo, ControlFlow, Msg, ToRedisArgs};
 use std::fmt::Debug;
 
+/// Errors related to asynchronous Redis Pub/Sub subscriber for standalone environment.
 #[derive(Debug)]
 pub enum RedisPubSubSubscriberErrorAsync {
+    /// Indicates that the connection address has already been used and cannot be reused.
     AddressAlreadyConsumed,
-    FailToOpenClientOfAddr { addr: String },
-    FailToOpenClientOfConnAddr { conn_addr: ConnectionAddr },
-    FailToOpenClientOfConnInfo { conn_info: ConnectionInfo },
-    FailToGetAsyncPubSub { conn_info: ConnectionInfo },
-    FailToSubscribeToChannels { conn_info: ConnectionInfo },
-    FailToSubscribeToChannelsWithPatterns { conn_info: ConnectionInfo },
-    FailToGetMessage { conn_info: ConnectionInfo },
+    /// Failed to open a Redis client with the specified address string.
+    FailToOpenClientOfAddr {
+        /// The Redis connection address string.
+        addr: String,
+    },
+    /// Failed to open a Redis client with the specified `ConnectionAddr`.
+    FailToOpenClientOfConnAddr {
+        /// The Redis `ConnectionAddr`.
+        conn_addr: ConnectionAddr,
+    },
+    /// Failed to open a Redis client with the specified `ConnectionInfo`.
+    FailToOpenClientOfConnInfo {
+        /// The Redis `ConnectionInfo`.
+        conn_info: ConnectionInfo,
+    },
+    /// Failed to get an asynchronous Pub/Sub connection from the client.
+    FailToGetAsyncPubSub {
+        /// The Redis `ConnectionInfo`.
+        conn_info: ConnectionInfo,
+    },
+    /// Failed to subscribe to the specified channels.
+    FailToSubscribeToChannels {
+        /// The Redis `ConnectionInfo`.
+        conn_info: ConnectionInfo,
+    },
+    /// Failed to subscribe to the specified patterns.
+    FailToSubscribeToChannelsWithPatterns {
+        /// The Redis `ConnectionInfo`.
+        conn_info: ConnectionInfo,
+    },
+    /// Failed to receive a message from the subscriber.
+    FailToGetMessage {
+        /// The Redis `ConnectionInfo`.
+        conn_info: ConnectionInfo,
+    },
 }
 
+/// A struct for subscribing to Redis channels and receiving messages asynchronously for standalone environment.
 pub struct RedisPubSubSubscriberAsync<A>
 where
     A: ToRedisArgs,
@@ -40,6 +71,15 @@ impl<A> RedisPubSubSubscriberAsync<A>
 where
     A: ToRedisArgs,
 {
+    /// Creates a new `RedisPubSubSubscriberAsync` with a connection address string.
+    ///
+    /// # Arguments
+    ///
+    /// * `addr` - A string slice that holds the Redis connection address.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisPubSubSubscriberAsync`.
     pub fn new<S>(addr: S) -> Self
     where
         S: AsRef<str>,
@@ -52,6 +92,15 @@ where
         }
     }
 
+    /// Creates a new `RedisPubSubSubscriberAsync` with a `ConnectionAddr`.
+    ///
+    /// # Arguments
+    ///
+    /// * `conn_addr` - A Redis `ConnectionAddr`.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisPubSubSubscriberAsync`.
     pub fn with_conn_addr(conn_addr: ConnectionAddr) -> Self {
         Self {
             addr: Some(RedisConfig::ConnAddr(conn_addr)),
@@ -61,6 +110,15 @@ where
         }
     }
 
+    /// Creates a new `RedisPubSubSubscriberAsync` with a `ConnectionInfo`.
+    ///
+    /// # Arguments
+    ///
+    /// * `conn_info` - A Redis `ConnectionInfo`.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisPubSubSubscriberAsync`.
     pub fn with_conn_info(conn_info: ConnectionInfo) -> Self {
         Self {
             addr: Some(RedisConfig::ConnInfo(conn_info)),
@@ -70,18 +128,46 @@ where
         }
     }
 
+    /// Sets the retry configuration for the subscriber.
+    ///
+    /// # Arguments
+    ///
+    /// * `max_count` - The maximum number of retry attempts.
+    /// * `init_delay_ms` - The initial delay between retries in milliseconds.
+    /// * `max_delay_ms` - The maximum delay between retries in milliseconds.
     pub fn set_retry(&mut self, max_count: u32, init_delay_ms: u64, max_delay_ms: u64) {
         self.retry = RetryAsync::with_params(max_count, init_delay_ms, max_delay_ms);
     }
 
+    /// Adds a channel to subscribe to.
+    ///
+    /// # Arguments
+    ///
+    /// * `channels` - The channel to subscribe to.
     pub fn subscribe(&mut self, channel: A) {
         self.channels.push(channel);
     }
 
+    /// Adds a pattern to subscribe to.
+    ///
+    /// # Arguments
+    ///
+    /// * `patterns` - The pattern to subscribe to.
     pub fn psubscribe(&mut self, pattern: A) {
         self.patterns.push(pattern);
     }
 
+    /// Starts receiving messages asynchronously and calls the provided callback for each message.
+    ///
+    /// This method continues until the callback returns `ControlFlow::Break`.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - A callback function that takes a `redis::Msg` and returns a `Future` that resolves to a `redis::ControlFlow`.
+    ///
+    /// # Returns
+    ///
+    /// A result containing the value returned by `ControlFlow::Break`, or an error.
     pub async fn receive_async<F, Fut, U>(mut self, mut f: F) -> errs::Result<U>
     where
         F: FnMut(Msg) -> Fut,


### PR DESCRIPTION
This PR adds documentation comments to the programming items:

- `RedisErrorAsync`
- `RedisDataConnAsync`
- `RedisDataSrcAsync`
- `RedisPubSubSubscriberErrorAsync`
- `RedisPubSubSubscriberAsync`