### PR TITLE
fix: corrected mistakes of parameter naming

### DIFF
--- a/src/cluster_std/pubsub.rs
+++ b/src/cluster_std/pubsub.rs
@@ -84,12 +84,12 @@ where
         self.retry = Retry::with_params(max_count, init_delay_ms, max_delay_ms);
     }
 
-    pub fn subscribe(&mut self, channels: A) {
-        self.channels.push(channels);
+    pub fn subscribe(&mut self, channel: A) {
+        self.channels.push(channel);
     }
 
-    pub fn psubscribe(&mut self, patterns: A) {
-        self.patterns.push(patterns);
+    pub fn psubscribe(&mut self, pattern: A) {
+        self.patterns.push(pattern);
     }
 
     pub fn receive<F, U>(mut self, mut f: F) -> errs::Result<U>

--- a/src/cluster_tokio/pubsub.rs
+++ b/src/cluster_tokio/pubsub.rs
@@ -85,12 +85,12 @@ where
         self.retry = RetryAsync::with_params(max_count, init_delay_ms, max_delay_ms);
     }
 
-    pub fn subscribe(&mut self, channels: A) {
-        self.channels.push(channels);
+    pub fn subscribe(&mut self, channel: A) {
+        self.channels.push(channel);
     }
 
-    pub fn psubscribe(&mut self, patterns: A) {
-        self.patterns.push(patterns);
+    pub fn psubscribe(&mut self, pattern: A) {
+        self.patterns.push(pattern);
     }
 
     pub async fn receive_async<F, Fut, U>(mut self, mut f: F) -> errs::Result<U>

--- a/src/sentinel_std/pubsub.rs
+++ b/src/sentinel_std/pubsub.rs
@@ -207,12 +207,12 @@ where
         self.retry = Retry::with_params(max_count, init_delay_ms, max_delay_ms);
     }
 
-    pub fn subscribe(&mut self, channels: A) {
-        self.channels.push(channels);
+    pub fn subscribe(&mut self, channel: A) {
+        self.channels.push(channel);
     }
 
-    pub fn psubscribe(&mut self, patterns: A) {
-        self.patterns.push(patterns);
+    pub fn psubscribe(&mut self, pattern: A) {
+        self.patterns.push(pattern);
     }
 
     pub fn receive<F, U>(mut self, mut f: F) -> errs::Result<U>

--- a/src/sentinel_tokio/pubsub.rs
+++ b/src/sentinel_tokio/pubsub.rs
@@ -206,12 +206,12 @@ where
         self.retry = RetryAsync::with_params(max_count, init_delay_ms, max_delay_ms);
     }
 
-    pub fn subscribe(&mut self, channels: A) {
-        self.channels.push(channels);
+    pub fn subscribe(&mut self, channel: A) {
+        self.channels.push(channel);
     }
 
-    pub fn psubscribe(&mut self, patterns: A) {
-        self.patterns.push(patterns);
+    pub fn psubscribe(&mut self, pattern: A) {
+        self.patterns.push(pattern);
     }
 
     pub async fn receive_async<F, Fut, U>(mut self, mut f: F) -> errs::Result<U>

--- a/src/standalone_std/pubsub.rs
+++ b/src/standalone_std/pubsub.rs
@@ -142,18 +142,18 @@ where
     ///
     /// # Arguments
     ///
-    /// * `channels` - The channel to subscribe to.
-    pub fn subscribe(&mut self, channels: A) {
-        self.channels.push(channels);
+    /// * `channel` - The channel to subscribe to.
+    pub fn subscribe(&mut self, channel: A) {
+        self.channels.push(channel);
     }
 
     /// Adds a pattern to subscribe to.
     ///
     /// # Arguments
     ///
-    /// * `patterns` - The pattern to subscribe to.
-    pub fn psubscribe(&mut self, patterns: A) {
-        self.patterns.push(patterns);
+    /// * `pattern` - The pattern to subscribe to.
+    pub fn psubscribe(&mut self, pattern: A) {
+        self.patterns.push(pattern);
     }
 
     /// Starts receiving messages and calls the provided callback for each message.

--- a/src/standalone_tokio/pubsub.rs
+++ b/src/standalone_tokio/pubsub.rs
@@ -74,12 +74,12 @@ where
         self.retry = RetryAsync::with_params(max_count, init_delay_ms, max_delay_ms);
     }
 
-    pub fn subscribe(&mut self, channels: A) {
-        self.channels.push(channels);
+    pub fn subscribe(&mut self, channel: A) {
+        self.channels.push(channel);
     }
 
-    pub fn psubscribe(&mut self, patterns: A) {
-        self.patterns.push(patterns);
+    pub fn psubscribe(&mut self, pattern: A) {
+        self.patterns.push(pattern);
     }
 
     pub async fn receive_async<F, Fut, U>(mut self, mut f: F) -> errs::Result<U>


### PR DESCRIPTION
This PR corrects the mistakes of parameter naming that plural forms are used for a single `channel` and `pattern`.

- `pub fn subscribe(&mut self, channels: A) ` --> `pub fn subscribe(&mut self, channel: A) `
- `pub fn psubscribe(&mut self, patterns: A)` --> `pub fn psubscribe(&mut self, pattern: A)`