### PR TITLE
doc,comment: changed 〜 environment to 〜 configuration in documentation comments

### DIFF
--- a/src/sentinel_std/mod.rs
+++ b/src/sentinel_std/mod.rs
@@ -16,7 +16,7 @@ use sabi::{AsyncGroup, DataConn, DataSrc};
 use std::fmt::Debug;
 use std::mem;
 
-/// Errors related to Redis data source and connection for Sentinel environment.
+/// Errors related to Redis data source and connection for Sentinel configuration.
 #[derive(Debug)]
 pub enum RedisError {
     /// Indicates that the data source is not yet setup.
@@ -85,7 +85,7 @@ pub enum RedisError {
     FailToGetConnectionFromPool,
 }
 
-/// A struct that holds a pooled Redis connection and transaction callbacks for Sentinel environment.
+/// A struct that holds a pooled Redis connection and transaction callbacks for Sentinel configuration.
 #[allow(clippy::type_complexity)]
 pub struct RedisDataConn {
     conn: PooledConnection<LockedSentinelClient>,
@@ -187,7 +187,7 @@ impl DataConn for RedisDataConn {
     fn close(&mut self) {}
 }
 
-/// A struct that manages a Redis Sentinel connection pool for Sentinel environment.
+/// A struct that manages a Redis Sentinel connection pool for Sentinel configuration.
 pub struct RedisDataSrc {
     pool: Option<RedisPool>,
 }

--- a/src/sentinel_std/pubsub.rs
+++ b/src/sentinel_std/pubsub.rs
@@ -10,7 +10,7 @@ use std::fmt::Debug;
 
 use crate::retry::Retry;
 
-/// Errors related to Redis Pub/Sub subscriber for Sentinel environment.
+/// Errors related to Redis Pub/Sub subscriber for Sentinel configuration.
 #[derive(Debug)]
 pub enum RedisPubSubSubscriberError {
     /// Indicates that the Sentinel configuration has already been used and cannot be reused.
@@ -54,7 +54,7 @@ pub enum RedisPubSubSubscriberError {
     FailToGetMessage,
 }
 
-/// A struct for subscribing to Redis channels and receiving messages for Sentinel environment.
+/// A struct for subscribing to Redis channels and receiving messages for Sentinel configuration.
 pub struct RedisPubSubSubscriber<A>
 where
     A: ToRedisArgs,

--- a/src/standalone_std/mod.rs
+++ b/src/standalone_std/mod.rs
@@ -44,7 +44,7 @@ pub enum RedisError {
 }
 
 /// A struct that holds a pooled Redis connection and transaction callbacks for standalone
-/// environment.
+/// configuration.
 #[allow(clippy::type_complexity)]
 pub struct RedisDataConn {
     conn: PooledConnection<Client>,

--- a/src/standalone_std/mod.rs
+++ b/src/standalone_std/mod.rs
@@ -12,7 +12,7 @@ use sabi::{AsyncGroup, DataConn, DataSrc};
 use std::fmt::Debug;
 use std::mem;
 
-/// Errors related to Redis data source and connection for standalone environment.
+/// Errors related to Redis data source and connection for standalone configuration.
 #[derive(Debug)]
 pub enum RedisError {
     /// Indicates that the data source is not yet setup.
@@ -146,7 +146,7 @@ impl DataConn for RedisDataConn {
     fn close(&mut self) {}
 }
 
-/// A struct that manages a Redis connection pool for standalone environment.
+/// A struct that manages a Redis connection pool for standalone configuration.
 pub struct RedisDataSrc {
     pool: Option<RedisPool>,
 }

--- a/src/standalone_std/pubsub.rs
+++ b/src/standalone_std/pubsub.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 
 use crate::retry::Retry;
 
-/// Errors related to Redis Pub/Sub subscriber for standalone environment.
+/// Errors related to Redis Pub/Sub subscriber for standalone configuration.
 #[derive(Debug)]
 pub enum RedisPubSubSubscriberError {
     /// Indicates that the connection address has already been used and cannot be reused.
@@ -49,7 +49,7 @@ pub enum RedisPubSubSubscriberError {
     },
 }
 
-/// A struct for subscribing to Redis channels and receiving messages for standalone environment.
+/// A struct for subscribing to Redis channels and receiving messages for standalone configuration.
 pub struct RedisPubSubSubscriber<A>
 where
     A: ToRedisArgs,

--- a/src/standalone_tokio/mod.rs
+++ b/src/standalone_tokio/mod.rs
@@ -12,7 +12,7 @@ use sabi::tokio::{AsyncGroup, DataConn, DataSrc};
 use std::future::Future;
 use std::{mem, pin, time};
 
-/// Errors related to Redis data source and connection for asynchronous standalone environment.
+/// Errors related to Redis data source and connection for asynchronous standalone configuration.
 #[derive(Debug)]
 pub enum RedisErrorAsync {
     /// Indicates that the data source is not yet setup.
@@ -35,7 +35,7 @@ pub enum RedisErrorAsync {
 
 type BoxedFuture = pin::Pin<Box<dyn Future<Output = errs::Result<()>> + Send + 'static>>;
 
-/// A struct that holds a Redis connection and asynchronous transaction callbacks for standalone environment.
+/// A struct that holds a Redis connection and asynchronous transaction callbacks for standalone configuration.
 pub struct RedisDataConnAsync {
     conn: Connection,
     pre_commit_vec: Vec<BoxedFuture>,
@@ -149,7 +149,7 @@ impl DataConn for RedisDataConnAsync {
     }
 }
 
-/// A struct that manages an asynchronous Redis connection pool for standalone environment.
+/// A struct that manages an asynchronous Redis connection pool for standalone configuration.
 pub struct RedisDataSrcAsync {
     pool: Option<RedisPool>,
 }

--- a/src/standalone_tokio/pubsub.rs
+++ b/src/standalone_tokio/pubsub.rs
@@ -8,7 +8,7 @@ use redis::aio::PubSub;
 use redis::{Client, ConnectionAddr, ConnectionInfo, ControlFlow, Msg, ToRedisArgs};
 use std::fmt::Debug;
 
-/// Errors related to asynchronous Redis Pub/Sub subscriber for standalone environment.
+/// Errors related to asynchronous Redis Pub/Sub subscriber for standalone configuration.
 #[derive(Debug)]
 pub enum RedisPubSubSubscriberErrorAsync {
     /// Indicates that the connection address has already been used and cannot be reused.
@@ -50,7 +50,7 @@ pub enum RedisPubSubSubscriberErrorAsync {
     },
 }
 
-/// A struct for subscribing to Redis channels and receiving messages asynchronously for standalone environment.
+/// A struct for subscribing to Redis channels and receiving messages asynchronously for standalone configuration.
 pub struct RedisPubSubSubscriberAsync<A>
 where
     A: ToRedisArgs,


### PR DESCRIPTION
Because 'sentinel configuration' is more appropriate than 'sentinel environment'.