### PR TITLE
doc,comment: added documentation comments to the items in sentinel_tokio module

### DIFF
--- a/src/sentinel_tokio/mod.rs
+++ b/src/sentinel_tokio/mod.rs
@@ -14,17 +14,30 @@ use std::future::Future;
 use std::{mem, pin};
 use tokio::time;
 
+/// Errors related to Redis data source and connection for asynchronous Sentinel configuration.
 #[derive(Debug)]
 pub enum RedisErrorAsync {
+    /// Indicates that the data source is already setup.
     AlreadySetup,
+    /// Indicates that the data source is not yet setup.
     NotSetupYet,
-    FailToConnect { config: Config },
-    FailToBuildPool { config: Config },
+    /// Failed to connect to Redis.
+    FailToConnect {
+        /// The Redis configuration.
+        config: Config,
+    },
+    /// Failed to build a Redis connection pool.
+    FailToBuildPool {
+        /// The Redis configuration.
+        config: Config,
+    },
+    /// Failed to get a connection from the pool.
     FailToGetConnectionFromPool,
 }
 
 type BoxedFuture = pin::Pin<Box<dyn Future<Output = errs::Result<()>> + Send + 'static>>;
 
+/// A struct that holds a Redis connection and asynchronous transaction callbacks for Sentinel configuration.
 pub struct RedisDataConnAsync {
     conn: Connection,
     pre_commit_vec: Vec<BoxedFuture>,
@@ -42,10 +55,20 @@ impl RedisDataConnAsync {
         }
     }
 
+    /// Returns a mutable reference to the underlying Redis multiplexed connection.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to the `redis::aio::MultiplexedConnection`.
     pub fn get_connection(&mut self) -> &mut MultiplexedConnection {
         &mut self.conn
     }
 
+    /// Adds an asynchronous callback function to be executed before a transaction is committed.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - A callback function that takes a `MultiplexedConnection` and returns a `Future`.
     pub async fn add_pre_commit_async<F, Fut>(&mut self, mut f: F)
     where
         F: FnMut(MultiplexedConnection) -> Fut,
@@ -55,6 +78,11 @@ impl RedisDataConnAsync {
         self.pre_commit_vec.push(Box::pin(fut))
     }
 
+    /// Adds an asynchronous callback function to be executed after a transaction is committed.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - A callback function that takes a `MultiplexedConnection` and returns a `Future`.
     pub async fn add_post_commit_async<F, Fut>(&mut self, mut f: F)
     where
         F: FnMut(MultiplexedConnection) -> Fut,
@@ -64,6 +92,11 @@ impl RedisDataConnAsync {
         self.post_commit_vec.push(Box::pin(fut))
     }
 
+    /// Adds an asynchronous callback function to be executed when a transaction is rolled back or forced back.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - A callback function that takes a `MultiplexedConnection` and returns a `Future`.
     pub async fn add_force_back_async<F, Fut>(&mut self, mut f: F)
     where
         F: FnMut(MultiplexedConnection) -> Fut,
@@ -118,6 +151,7 @@ impl DataConn for RedisDataConnAsync {
     }
 }
 
+/// A struct that manages an asynchronous Redis connection pool for Sentinel configuration.
 pub struct RedisDataSrcAsync {
     pool: Option<RedisPool>,
 }
@@ -128,6 +162,17 @@ enum RedisPool {
 }
 
 impl RedisDataSrcAsync {
+    /// Creates a new `RedisDataSrcAsync` with Sentinel address strings.
+    ///
+    /// # Arguments
+    ///
+    /// * `addrs` - An iterator of string slices that hold the Sentinel connection addresses.
+    /// * `master_name` - The service name of the Redis master.
+    /// * `server_type` - The type of Redis server (Master or Slave).
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisDataSrcAsync`.
     pub fn new<I, S>(addrs: I, master_name: S, server_type: SentinelServerType) -> Self
     where
         I: IntoIterator<Item: AsRef<str>>,
@@ -146,6 +191,18 @@ impl RedisDataSrcAsync {
         }
     }
 
+    /// Creates a new `RedisDataSrcAsync` with Sentinel address strings and pool configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `addrs` - An iterator of string slices that hold the Sentinel connection addresses.
+    /// * `master_name` - The service name of the Redis master.
+    /// * `server_type` - The type of Redis server (Master or Slave).
+    /// * `pool_config` - The configuration for the connection pool.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisDataSrcAsync`.
     pub fn with_pool_config<I, S>(
         addrs: I,
         master_name: S,
@@ -169,6 +226,15 @@ impl RedisDataSrcAsync {
         }
     }
 
+    /// Creates a new `RedisDataSrcAsync` with a `deadpool_redis::sentinel::Config`.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - A `deadpool_redis::sentinel::Config`.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisDataSrcAsync`.
     pub fn with_config(config: Config) -> Self {
         Self {
             pool: Some(RedisPool::Config(Box::new(config))),

--- a/src/sentinel_tokio/pubsub.rs
+++ b/src/sentinel_tokio/pubsub.rs
@@ -11,32 +11,53 @@ use std::fmt::Debug;
 
 use crate::retry_async::RetryAsync;
 
+/// Errors related to asynchronous Redis Pub/Sub subscriber for Sentinel configuration.
 #[derive(Debug)]
 pub enum RedisPubSubSubscriberErrorAsync {
+    /// Indicates that the Sentinel configuration has already been used and cannot be reused.
     SentinelConfigAlreadyConsumed,
+    /// Failed to build a Sentinel client with the specified address strings.
     FailToBuildSentinelClientOfAddrs {
+        /// The Sentinel connection address strings.
         addrs: Vec<String>,
+        /// The service name of the Redis master.
         service_name: String,
+        /// The type of Redis server (Master or Slave).
         server_type: SentinelServerType,
     },
+    /// Failed to build a Sentinel client with the specified `ConnectionAddr`s.
     FailToBuildSentinelClientOfConnAddrs {
+        /// The Sentinel `ConnectionAddr`s.
         conn_addrs: Vec<ConnectionAddr>,
+        /// The service name of the Redis master.
         service_name: String,
+        /// The type of Redis server (Master or Slave).
         server_type: SentinelServerType,
     },
+    /// Failed to build a Sentinel client with the specified `ConnectionInfo`s.
     FailToBuildSentinelClientOfConnInfos {
+        /// The Sentinel `ConnectionInfo`s.
         conn_infos: Vec<ConnectionInfo>,
+        /// The service name of the Redis master.
         service_name: String,
+        /// The type of Redis server (Master or Slave).
         server_type: SentinelServerType,
     },
+    /// Failed to build a Sentinel client with the specified `SentinelClientBuilder`.
     FailToBuildSentinelClientWithClientBuilder,
+    /// Failed to get a client of the specified server type.
     FailToGetClientOfServerType,
+    /// Failed to get an asynchronous Pub/Sub connection.
     FailToGetAsyncPubSub,
+    /// Failed to subscribe to the specified channels.
     FailToSubscribeToChannels,
+    /// Failed to subscribe to the specified patterns.
     FailToSubscribeToChannelsWithPatterns,
+    /// Failed to receive a message from the subscriber.
     FailToGetMessage,
 }
 
+/// A struct for subscribing to Redis channels and receiving messages asynchronously for Sentinel configuration.
 pub struct RedisPubSubSubscriberAsync<A> {
     config: Option<SentinelConfig>,
     channels: Vec<A>,
@@ -62,6 +83,17 @@ impl<A> RedisPubSubSubscriberAsync<A>
 where
     A: ToRedisArgs,
 {
+    /// Creates a new `RedisPubSubSubscriberAsync` with Sentinel address strings.
+    ///
+    /// # Arguments
+    ///
+    /// * `addrs` - An iterator of string slices that hold the Sentinel connection addresses.
+    /// * `service_name` - The service name of the Redis master.
+    /// * `server_type` - The type of Redis server (Master or Slave).
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisPubSubSubscriberAsync`.
     pub fn new<I, S>(addrs: I, service_name: S, server_type: SentinelServerType) -> Self
     where
         I: IntoIterator<Item: AsRef<str>>,
@@ -80,6 +112,18 @@ where
         }
     }
 
+    /// Creates a new `RedisPubSubSubscriberAsync` with Sentinel address strings and node connection info.
+    ///
+    /// # Arguments
+    ///
+    /// * `addrs` - An iterator of string slices that hold the Sentinel connection addresses.
+    /// * `service_name` - The service name of the Redis master.
+    /// * `server_type` - The type of Redis server (Master or Slave).
+    /// * `node_conn_info` - The connection info for the Redis node.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisPubSubSubscriberAsync`.
     pub fn with_node_conn_info<I, S>(
         addrs: I,
         service_name: S,
@@ -103,6 +147,17 @@ where
         }
     }
 
+    /// Creates a new `RedisPubSubSubscriberAsync` with Sentinel `ConnectionAddr`s.
+    ///
+    /// # Arguments
+    ///
+    /// * `conn_addrs` - An iterator of `ConnectionAddr`s.
+    /// * `service_name` - The service name of the Redis master.
+    /// * `server_type` - The type of Redis server (Master or Slave).
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisPubSubSubscriberAsync`.
     pub fn with_conn_addrs<I, S>(
         conn_addrs: I,
         service_name: S,
@@ -125,6 +180,18 @@ where
         }
     }
 
+    /// Creates a new `RedisPubSubSubscriberAsync` with Sentinel `ConnectionAddr`s and node connection info.
+    ///
+    /// # Arguments
+    ///
+    /// * `conn_addrs` - An iterator of `ConnectionAddr`s.
+    /// * `service_name` - The service name of the Redis master.
+    /// * `server_type` - The type of Redis server (Master or Slave).
+    /// * `node_conn_info` - The connection info for the Redis node.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisPubSubSubscriberAsync`.
     pub fn with_conn_addrs_and_node_conn_info<I, S>(
         conn_addrs: I,
         service_name: S,
@@ -148,6 +215,17 @@ where
         }
     }
 
+    /// Creates a new `RedisPubSubSubscriberAsync` with Sentinel `ConnectionInfo`s.
+    ///
+    /// # Arguments
+    ///
+    /// * `conn_infos` - An iterator of `ConnectionInfo`s.
+    /// * `service_name` - The service name of the Redis master.
+    /// * `server_type` - The type of Redis server (Master or Slave).
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisPubSubSubscriberAsync`.
     pub fn with_conn_infos<I, S>(
         conn_infos: I,
         service_name: S,
@@ -170,6 +248,18 @@ where
         }
     }
 
+    /// Creates a new `RedisPubSubSubscriberAsync` with Sentinel `ConnectionInfo`s and node connection info.
+    ///
+    /// # Arguments
+    ///
+    /// * `conn_infos` - An iterator of `ConnectionInfo`s.
+    /// * `service_name` - The service name of the Redis master.
+    /// * `server_type` - The type of Redis server (Master or Slave).
+    /// * `node_conn_info` - The connection info for the Redis node.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisPubSubSubscriberAsync`.
     pub fn with_conn_infos_and_node_conn_info<I, S>(
         conn_infos: I,
         service_name: S,
@@ -193,6 +283,15 @@ where
         }
     }
 
+    /// Creates a new `RedisPubSubSubscriberAsync` with a `SentinelClientBuilder`.
+    ///
+    /// # Arguments
+    ///
+    /// * `client_builder` - A `redis::sentinel::SentinelClientBuilder`.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisPubSubSubscriberAsync`.
     pub fn with_client_builder(client_builder: SentinelClientBuilder) -> Self {
         Self {
             config: Some(SentinelConfig::ClientBuilder(Box::new(client_builder))),
@@ -202,18 +301,44 @@ where
         }
     }
 
+    /// Sets the retry configuration for the subscriber.
+    ///
+    /// # Arguments
+    ///
+    /// * `max_count` - The maximum number of retry attempts.
+    /// * `init_delay_ms` - The initial delay between retries in milliseconds.
+    /// * `max_delay_ms` - The maximum delay between retries in milliseconds.
     pub fn set_retry(&mut self, max_count: u32, init_delay_ms: u64, max_delay_ms: u64) {
         self.retry = RetryAsync::with_params(max_count, init_delay_ms, max_delay_ms);
     }
 
+    /// Adds a channel to subscribe to.
+    ///
+    /// # Arguments
+    ///
+    /// * `channel` - The channel to subscribe to.
     pub fn subscribe(&mut self, channel: A) {
         self.channels.push(channel);
     }
 
+    /// Adds a pattern to subscribe to.
+    ///
+    /// # Arguments
+    ///
+    /// * `pattern` - The pattern to subscribe to.
     pub fn psubscribe(&mut self, pattern: A) {
         self.patterns.push(pattern);
     }
 
+    /// Starts receiving messages asynchronously and calls the provided callback for each message.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - A callback function that takes a `redis::Msg` and returns a `Future` that resolves to a `redis::ControlFlow`.
+    ///
+    /// # Returns
+    ///
+    /// A result containing the value returned by `ControlFlow::Break`, or an error.
     pub async fn receive_async<F, Fut, U>(mut self, mut f: F) -> errs::Result<U>
     where
         F: FnMut(Msg) -> Fut,


### PR DESCRIPTION
This PR adds documentation comments to the programming items in `src/sentinel_tokio/`:

- `RedisErrorAsync`
- `RedisDataConnAsync`
- `RedisDataSrcAsync`
- `RedisPubSubSubscriberErrorAsync`
- `RedisPubSubSubscriberAsync`