### PR TITLE
doc,comment: added documentation comments to the items in cluster_std module

### DIFF
--- a/src/cluster_std/mod.rs
+++ b/src/cluster_std/mod.rs
@@ -14,21 +14,52 @@ use redis::{ConnectionAddr, ConnectionInfo};
 use std::fmt::Debug;
 use std::mem;
 
+/// Errors related to Redis data source and connection for cluster configuration.
 #[derive(Debug)]
 pub enum RedisError {
+    /// Indicates that the data source is not yet setup.
     NotSetupYet,
+    /// Indicates that the data source is already setup.
     AlreadySetup,
-    FailToBuildClientOfAddrs { addrs: Vec<String> },
-    FailToBuildPoolOfAddrs { addrs: Vec<String> },
-    FailToBuildClientOfConnAddrs { conn_addrs: Vec<ConnectionAddr> },
-    FailToBuildPoolOfConnAddrs { conn_addrs: Vec<ConnectionAddr> },
-    FailToBuildClientOfConnInfos { conn_infos: Vec<ConnectionInfo> },
-    FailToBuildPoolOfConnInfos { conn_infos: Vec<ConnectionInfo> },
+    /// Failed to build a cluster client with the specified address strings.
+    FailToBuildClientOfAddrs {
+        /// The cluster node address strings.
+        addrs: Vec<String>,
+    },
+    /// Failed to build a connection pool with the specified address strings.
+    FailToBuildPoolOfAddrs {
+        /// The cluster node address strings.
+        addrs: Vec<String>,
+    },
+    /// Failed to build a cluster client with the specified `ConnectionAddr`s.
+    FailToBuildClientOfConnAddrs {
+        /// The cluster node `ConnectionAddr`s.
+        conn_addrs: Vec<ConnectionAddr>,
+    },
+    /// Failed to build a connection pool with the specified `ConnectionAddr`s.
+    FailToBuildPoolOfConnAddrs {
+        /// The cluster node `ConnectionAddr`s.
+        conn_addrs: Vec<ConnectionAddr>,
+    },
+    /// Failed to build a cluster client with the specified `ConnectionInfo`s.
+    FailToBuildClientOfConnInfos {
+        /// The cluster node `ConnectionInfo`s.
+        conn_infos: Vec<ConnectionInfo>,
+    },
+    /// Failed to build a connection pool with the specified `ConnectionInfo`s.
+    FailToBuildPoolOfConnInfos {
+        /// The cluster node `ConnectionInfo`s.
+        conn_infos: Vec<ConnectionInfo>,
+    },
+    /// Failed to build a cluster client with the specified `ClusterClientBuilder`.
     FailToBuildClientWithClientBuilder,
+    /// Failed to build a connection pool with the specified `ClusterClientBuilder`.
     FailToBuildPoolWithClientBuilder,
+    /// Failed to get a connection from the pool.
     FailToGetConnectionFromPool,
 }
 
+/// A struct that holds a pooled Redis cluster connection and transaction callbacks for cluster configuration.
 #[allow(clippy::type_complexity)]
 pub struct RedisDataConn {
     conn: PooledConnection<ClusterClient>,
@@ -47,10 +78,20 @@ impl RedisDataConn {
         }
     }
 
+    /// Returns a mutable reference to the underlying pooled Redis cluster connection.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to the `r2d2::PooledConnection<ClusterClient>`.
     pub fn get_connection(&mut self) -> &mut PooledConnection<ClusterClient> {
         &mut self.conn
     }
 
+    /// Adds a callback function to be executed before a transaction is committed.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - A callback function that takes a mutable reference to the cluster connection.
     pub fn add_pre_commit<F>(&mut self, f: F)
     where
         F: FnMut(&mut ClusterConnection) -> errs::Result<()> + 'static,
@@ -58,6 +99,11 @@ impl RedisDataConn {
         self.pre_commit_vec.push(Box::new(f));
     }
 
+    /// Adds a callback function to be executed after a transaction is committed.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - A callback function that takes a mutable reference to the cluster connection.
     pub fn add_post_commit<F>(&mut self, f: F)
     where
         F: FnMut(&mut ClusterConnection) -> errs::Result<()> + 'static,
@@ -65,6 +111,11 @@ impl RedisDataConn {
         self.post_commit_vec.push(Box::new(f));
     }
 
+    /// Adds a callback function to be executed when a transaction is rolled back or forced back.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - A callback function that takes a mutable reference to the cluster connection.
     pub fn add_force_back<F>(&mut self, f: F)
     where
         F: FnMut(&mut ClusterConnection) -> errs::Result<()> + 'static,
@@ -110,6 +161,7 @@ impl DataConn for RedisDataConn {
     fn close(&mut self) {}
 }
 
+/// A struct that manages a Redis cluster connection pool for cluster configuration.
 pub struct RedisDataSrc {
     pool: Option<RedisPool>,
 }
@@ -123,6 +175,15 @@ enum RedisPool {
 }
 
 impl RedisDataSrc {
+    /// Creates a new `RedisDataSrc` with cluster node address strings.
+    ///
+    /// # Arguments
+    ///
+    /// * `addrs` - An iterator of string slices that hold the cluster node addresses.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisDataSrc`.
     pub fn new<I>(addrs: I) -> Self
     where
         I: IntoIterator<Item: AsRef<str>>,
@@ -133,6 +194,16 @@ impl RedisDataSrc {
         }
     }
 
+    /// Creates a new `RedisDataSrc` with cluster node address strings and a pool builder.
+    ///
+    /// # Arguments
+    ///
+    /// * `addrs` - An iterator of string slices that hold the cluster node addresses.
+    /// * `pool_builder` - A `r2d2::Builder<ClusterClient>`.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisDataSrc`.
     pub fn with_pool_builder<I>(addrs: I, pool_builder: Builder<ClusterClient>) -> Self
     where
         I: IntoIterator<Item: AsRef<str>>,
@@ -143,6 +214,15 @@ impl RedisDataSrc {
         }
     }
 
+    /// Creates a new `RedisDataSrc` with cluster node `ConnectionAddr`s.
+    ///
+    /// # Arguments
+    ///
+    /// * `conn_addrs` - An iterator of `ConnectionAddr`s.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisDataSrc`.
     pub fn with_conn_addrs<I>(conn_addrs: I) -> Self
     where
         I: IntoIterator<Item = ConnectionAddr>,
@@ -156,6 +236,16 @@ impl RedisDataSrc {
         }
     }
 
+    /// Creates a new `RedisDataSrc` with cluster node `ConnectionAddr`s and a pool builder.
+    ///
+    /// # Arguments
+    ///
+    /// * `conn_addrs` - An iterator of `ConnectionAddr`s.
+    /// * `pool_builder` - A `r2d2::Builder<ClusterClient>`.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisDataSrc`.
     pub fn with_conn_addrs_and_pool_builder<I>(
         conn_addrs: I,
         pool_builder: Builder<ClusterClient>,
@@ -172,6 +262,15 @@ impl RedisDataSrc {
         }
     }
 
+    /// Creates a new `RedisDataSrc` with cluster node `ConnectionInfo`s.
+    ///
+    /// # Arguments
+    ///
+    /// * `conn_infos` - An iterator of `ConnectionInfo`s.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisDataSrc`.
     pub fn with_conn_infos<I>(conn_infos: I) -> Self
     where
         I: IntoIterator<Item = ConnectionInfo>,
@@ -185,6 +284,16 @@ impl RedisDataSrc {
         }
     }
 
+    /// Creates a new `RedisDataSrc` with cluster node `ConnectionInfo`s and a pool builder.
+    ///
+    /// # Arguments
+    ///
+    /// * `conn_infos` - An iterator of `ConnectionInfo`s.
+    /// * `pool_builder` - A `r2d2::Builder<ClusterClient>`.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisDataSrc`.
     pub fn with_conn_infos_and_pool_builder<I>(
         conn_infos: I,
         pool_builder: Builder<ClusterClient>,
@@ -201,6 +310,15 @@ impl RedisDataSrc {
         }
     }
 
+    /// Creates a new `RedisDataSrc` with a `ClusterClientBuilder`.
+    ///
+    /// # Arguments
+    ///
+    /// * `client_builder` - A `redis::cluster::ClusterClientBuilder`.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisDataSrc`.
     pub fn with_client_builder(client_builder: ClusterClientBuilder) -> Self {
         Self {
             pool: Some(RedisPool::ClientBuilderConfig(Box::new((
@@ -210,6 +328,16 @@ impl RedisDataSrc {
         }
     }
 
+    /// Creates a new `RedisDataSrc` with a `ClusterClientBuilder` and a pool builder.
+    ///
+    /// # Arguments
+    ///
+    /// * `client_builder` - A `redis::cluster::ClusterClientBuilder`.
+    /// * `pool_builder` - A `r2d2::Builder<ClusterClient>`.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisDataSrc`.
     pub fn with_client_builder_and_pool_builder(
         client_builder: ClusterClientBuilder,
         pool_builder: Builder<ClusterClient>,

--- a/src/cluster_std/pubsub.rs
+++ b/src/cluster_std/pubsub.rs
@@ -10,18 +10,40 @@ use std::fmt::Debug;
 
 use crate::retry::Retry;
 
+/// Errors related to Redis Pub/Sub subscriber for cluster configuration.
 #[derive(Debug)]
 pub enum RedisPubSubSubscriberError {
+    /// Indicates that the cluster configuration has already been used and cannot be reused.
     ClusterConfigAlreadyConsumed,
-    InvalidAddrs { addrs: Vec<String> },
-    InvalidConnAddrs { conn_addrs: Vec<ConnectionAddr> },
-    FailToOpenClient { conn_info: ConnectionInfo },
-    FailToGetConnection { conn_info: ConnectionInfo },
+    /// The specified address strings are invalid.
+    InvalidAddrs {
+        /// The invalid address strings.
+        addrs: Vec<String>,
+    },
+    /// The specified `ConnectionAddr`s are invalid.
+    InvalidConnAddrs {
+        /// The invalid `ConnectionAddr`s.
+        conn_addrs: Vec<ConnectionAddr>,
+    },
+    /// Failed to open a Redis client.
+    FailToOpenClient {
+        /// The Redis `ConnectionInfo`.
+        conn_info: ConnectionInfo,
+    },
+    /// Failed to get a connection from the client.
+    FailToGetConnection {
+        /// The Redis `ConnectionInfo`.
+        conn_info: ConnectionInfo,
+    },
+    /// Failed to subscribe to the specified channels.
     FailToSubscribeToChannels,
+    /// Failed to subscribe to the specified patterns.
     FailToSubscribeToChannelsWithPatterns,
+    /// Failed to receive a message from the subscriber.
     FailToGetMessage,
 }
 
+/// A struct for subscribing to Redis channels and receiving messages for cluster configuration.
 pub struct RedisPubSubSubscriber<A>
 where
     A: ToRedisArgs,
@@ -42,6 +64,15 @@ impl<A> RedisPubSubSubscriber<A>
 where
     A: ToRedisArgs,
 {
+    /// Creates a new `RedisPubSubSubscriber` with cluster node address strings.
+    ///
+    /// # Arguments
+    ///
+    /// * `addrs` - An iterator of string slices that hold the cluster node addresses.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisPubSubSubscriber`.
     pub fn new<I>(addrs: I) -> Self
     where
         I: IntoIterator<Item: AsRef<str>>,
@@ -56,6 +87,15 @@ where
         }
     }
 
+    /// Creates a new `RedisPubSubSubscriber` with cluster node `ConnectionAddr`s.
+    ///
+    /// # Arguments
+    ///
+    /// * `conn_addrs` - An iterator of `ConnectionAddr`s.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisPubSubSubscriber`.
     pub fn with_conn_addrs<I>(conn_addrs: I) -> Self
     where
         I: IntoIterator<Item = ConnectionAddr>,
@@ -68,6 +108,15 @@ where
         }
     }
 
+    /// Creates a new `RedisPubSubSubscriber` with cluster node `ConnectionInfo`s.
+    ///
+    /// # Arguments
+    ///
+    /// * `conn_infos` - An iterator of `ConnectionInfo`s.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisPubSubSubscriber`.
     pub fn with_conn_infos<I>(conn_infos: I) -> Self
     where
         I: IntoIterator<Item = ConnectionInfo>,
@@ -80,18 +129,46 @@ where
         }
     }
 
+    /// Sets the retry configuration for the subscriber.
+    ///
+    /// # Arguments
+    ///
+    /// * `max_count` - The maximum number of retry attempts.
+    /// * `init_delay_ms` - The initial delay between retries in milliseconds.
+    /// * `max_delay_ms` - The maximum delay between retries in milliseconds.
     pub fn set_retry(&mut self, max_count: u32, init_delay_ms: u64, max_delay_ms: u64) {
         self.retry = Retry::with_params(max_count, init_delay_ms, max_delay_ms);
     }
 
+    /// Adds a channel to subscribe to.
+    ///
+    /// # Arguments
+    ///
+    /// * `channel` - The channel to subscribe to.
     pub fn subscribe(&mut self, channel: A) {
         self.channels.push(channel);
     }
 
+    /// Adds a pattern to subscribe to.
+    ///
+    /// # Arguments
+    ///
+    /// * `pattern` - The pattern to subscribe to.
     pub fn psubscribe(&mut self, pattern: A) {
         self.patterns.push(pattern);
     }
 
+    /// Starts receiving messages and calls the provided callback for each message.
+    ///
+    /// This method blocks until the callback returns `ControlFlow::Break`.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - A callback function that takes a `redis::Msg` and returns a `redis::ControlFlow`.
+    ///
+    /// # Returns
+    ///
+    /// A result containing the value returned by `ControlFlow::Break`, or an error.
     pub fn receive<F, U>(mut self, mut f: F) -> errs::Result<U>
     where
         F: FnMut(Msg) -> ControlFlow<U>,


### PR DESCRIPTION
This PR adds documentation comments to the programming items in `src/cluster_std`:

- `RedisError`
- `RedisDataConn`
- `RedisDataSrc`
- `RedisPubSubSubscriberError`
- `RedisPubSubSubscriber`