### PR TITLE
doc,comment: added documentation comments to the items in cluster_tokio module

### DIFF
--- a/src/cluster_tokio/mod.rs
+++ b/src/cluster_tokio/mod.rs
@@ -12,17 +12,30 @@ use std::future::Future;
 use std::{mem, pin};
 use tokio::time;
 
+/// Errors related to Redis data source and connection for asynchronous cluster configuration.
 #[derive(Debug)]
 pub enum RedisErrorAsync {
+    /// Indicates that the data source is not yet setup.
     NotSetupYet,
+    /// Indicates that the data source is already setup.
     AlreadySetup,
-    FailToConnect { config: Config },
-    FailToBuildPool { config: Config },
+    /// Failed to connect to Redis.
+    FailToConnect {
+        /// The Redis configuration.
+        config: Config,
+    },
+    /// Failed to build a Redis connection pool.
+    FailToBuildPool {
+        /// The Redis configuration.
+        config: Config,
+    },
+    /// Failed to get a connection from the pool.
     FailToGetConnectionFromPool,
 }
 
 type BoxedFuture = pin::Pin<Box<dyn Future<Output = errs::Result<()>> + Send + 'static>>;
 
+/// A struct that holds a Redis cluster connection and asynchronous transaction callbacks for cluster configuration.
 pub struct RedisDataConnAsync {
     conn: Connection,
     pre_commit_vec: Vec<BoxedFuture>,
@@ -40,10 +53,20 @@ impl RedisDataConnAsync {
         }
     }
 
+    /// Returns a mutable reference to the underlying Redis cluster multiplexed connection.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to the `redis::aio::Connection`.
     pub fn get_connection(&mut self) -> &mut ClusterConnection {
         &mut self.conn
     }
 
+    /// Adds an asynchronous callback function to be executed before a transaction is committed.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - A callback function that takes a `ClusterConnection` and returns a `Future`.
     pub async fn add_pre_commit_async<F, Fut>(&mut self, mut f: F)
     where
         F: FnMut(ClusterConnection) -> Fut,
@@ -53,6 +76,11 @@ impl RedisDataConnAsync {
         self.pre_commit_vec.push(Box::pin(fut))
     }
 
+    /// Adds an asynchronous callback function to be executed after a transaction is committed.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - A callback function that takes a `ClusterConnection` and returns a `Future`.
     pub async fn add_post_commit_async<F, Fut>(&mut self, mut f: F)
     where
         F: FnMut(ClusterConnection) -> Fut,
@@ -62,6 +90,11 @@ impl RedisDataConnAsync {
         self.post_commit_vec.push(Box::pin(fut))
     }
 
+    /// Adds an asynchronous callback function to be executed when a transaction is rolled back or forced back.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - A callback function that takes a `ClusterConnection` and returns a `Future`.
     pub async fn add_force_back_async<F, Fut>(&mut self, mut f: F)
     where
         F: FnMut(ClusterConnection) -> Fut,
@@ -116,6 +149,7 @@ impl DataConn for RedisDataConnAsync {
     }
 }
 
+/// A struct that manages an asynchronous Redis cluster connection pool for cluster configuration.
 pub struct RedisDataSrcAsync {
     pool: Option<RedisPool>,
 }
@@ -126,6 +160,15 @@ enum RedisPool {
 }
 
 impl RedisDataSrcAsync {
+    /// Creates a new `RedisDataSrcAsync` with cluster node address strings.
+    ///
+    /// # Arguments
+    ///
+    /// * `addrs` - An iterator of string slices that hold the cluster node addresses.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisDataSrcAsync`.
     pub fn new<I>(addrs: I) -> Self
     where
         I: IntoIterator<Item: AsRef<str>>,
@@ -141,6 +184,16 @@ impl RedisDataSrcAsync {
         }
     }
 
+    /// Creates a new `RedisDataSrcAsync` with cluster node address strings and pool configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `addrs` - An iterator of string slices that hold the cluster node addresses.
+    /// * `pool_config` - The configuration for the connection pool.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisDataSrcAsync`.
     pub fn with_pool_config<I>(addrs: I, pool_config: PoolConfig) -> Self
     where
         I: IntoIterator<Item: AsRef<str>>,
@@ -156,6 +209,15 @@ impl RedisDataSrcAsync {
         }
     }
 
+    /// Creates a new `RedisDataSrcAsync` with a `deadpool_redis::cluster::Config`.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - A `deadpool_redis::cluster::Config`.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisDataSrcAsync`.
     pub fn with_config(config: Config) -> Self {
         Self {
             pool: Some(RedisPool::Config(Box::new(config))),

--- a/src/cluster_tokio/pubsub.rs
+++ b/src/cluster_tokio/pubsub.rs
@@ -10,19 +10,45 @@ use redis::{
 };
 use std::fmt::Debug;
 
+/// Errors related to asynchronous Redis Pub/Sub subscriber for cluster configuration.
 #[derive(Debug)]
 pub enum RedisPubSubSubscriberErrorAsync {
+    /// Indicates that the cluster configuration has already been used and cannot be reused.
     ClusterConfigAlreadyConsumed,
-    InvalidAddrs { addrs: Vec<String> },
-    InvalidConnAddrs { conn_addrs: Vec<ConnectionAddr> },
-    FailToOpenClient { conn_info: ConnectionInfo },
-    FailToGetAsyncPubSub { conn_info: ConnectionInfo },
-    FailToGetConnection { conn_info: ConnectionInfo },
+    /// The specified address strings are invalid.
+    InvalidAddrs {
+        /// The invalid address strings.
+        addrs: Vec<String>,
+    },
+    /// The specified `ConnectionAddr`s are invalid.
+    InvalidConnAddrs {
+        /// The invalid `ConnectionAddr`s.
+        conn_addrs: Vec<ConnectionAddr>,
+    },
+    /// Failed to open a Redis client.
+    FailToOpenClient {
+        /// The Redis `ConnectionInfo`.
+        conn_info: ConnectionInfo,
+    },
+    /// Failed to get an asynchronous Pub/Sub connection.
+    FailToGetAsyncPubSub {
+        /// The Redis `ConnectionInfo`.
+        conn_info: ConnectionInfo,
+    },
+    /// Failed to get a connection.
+    FailToGetConnection {
+        /// The Redis `ConnectionInfo`.
+        conn_info: ConnectionInfo,
+    },
+    /// Failed to subscribe to the specified channels.
     FailToSubscribeToChannels,
+    /// Failed to subscribe to the specified patterns.
     FailToSubscribeToChannelsWithPatterns,
+    /// Failed to receive a message from the subscriber.
     FailToGetMessage,
 }
 
+/// A struct for subscribing to Redis channels and receiving messages asynchronously for cluster configuration.
 pub struct RedisPubSubSubscriberAsync<A>
 where
     A: ToRedisArgs,
@@ -43,6 +69,15 @@ impl<A> RedisPubSubSubscriberAsync<A>
 where
     A: ToRedisArgs,
 {
+    /// Creates a new `RedisPubSubSubscriberAsync` with cluster node address strings.
+    ///
+    /// # Arguments
+    ///
+    /// * `addrs` - An iterator of string slices that hold the cluster node addresses.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisPubSubSubscriberAsync`.
     pub fn new<I>(addrs: I) -> Self
     where
         I: IntoIterator<Item: AsRef<str>>,
@@ -57,6 +92,15 @@ where
         }
     }
 
+    /// Creates a new `RedisPubSubSubscriberAsync` with cluster node `ConnectionAddr`s.
+    ///
+    /// # Arguments
+    ///
+    /// * `conn_addrs` - An iterator of `ConnectionAddr`s.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisPubSubSubscriberAsync`.
     pub fn with_conn_addrs<I>(conn_addrs: I) -> Self
     where
         I: IntoIterator<Item = ConnectionAddr>,
@@ -69,6 +113,15 @@ where
         }
     }
 
+    /// Creates a new `RedisPubSubSubscriberAsync` with cluster node `ConnectionInfo`s.
+    ///
+    /// # Arguments
+    ///
+    /// * `conn_infos` - An iterator of `ConnectionInfo`s.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisPubSubSubscriberAsync`.
     pub fn with_conn_infos<I>(conn_infos: I) -> Self
     where
         I: IntoIterator<Item = ConnectionInfo>,
@@ -81,18 +134,44 @@ where
         }
     }
 
+    /// Sets the retry configuration for the subscriber.
+    ///
+    /// # Arguments
+    ///
+    /// * `max_count` - The maximum number of retry attempts.
+    /// * `init_delay_ms` - The initial delay between retries in milliseconds.
+    /// * `max_delay_ms` - The maximum delay between retries in milliseconds.
     pub fn set_retry(&mut self, max_count: u32, init_delay_ms: u64, max_delay_ms: u64) {
         self.retry = RetryAsync::with_params(max_count, init_delay_ms, max_delay_ms);
     }
 
+    /// Adds a channel to subscribe to.
+    ///
+    /// # Arguments
+    ///
+    /// * `channel` - The channel to subscribe to.
     pub fn subscribe(&mut self, channel: A) {
         self.channels.push(channel);
     }
 
+    /// Adds a pattern to subscribe to.
+    ///
+    /// # Arguments
+    ///
+    /// * `pattern` - The pattern to subscribe to.
     pub fn psubscribe(&mut self, pattern: A) {
         self.patterns.push(pattern);
     }
 
+    /// Starts receiving messages asynchronously and calls the provided callback for each message.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - A callback function that takes a `redis::Msg` and returns a `Future` that resolves to a `redis::ControlFlow`.
+    ///
+    /// # Returns
+    ///
+    /// A result containing the value returned by `ControlFlow::Break`, or an error.
     pub async fn receive_async<F, Fut, U>(mut self, mut f: F) -> errs::Result<U>
     where
         F: FnMut(Msg) -> Fut,


### PR DESCRIPTION
This PR adds documentation comments to the programming items in `src/cluster_tokio/`:

- `RedisErrorAsync`
- `RedisDataConnAsync`
- `RedisDataSrcAsync`
- `RedisPubSubSubscriberErrorAsync`
- `RedisPubSubSubscriberAsync`