### PR TITLE
doc,comment: added documentation comments to public APIs directly under src/

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ mod sentinel_std;
 #[cfg(feature = "sentinel-async")]
 mod sentinel_tokio;
 
+/// A module for Redis Sentinel.
 #[cfg(any(feature = "sentinel", feature = "sentinel-async"))]
 pub mod sentinel {
     #[cfg(feature = "sentinel")]
@@ -51,6 +52,7 @@ mod cluster_std;
 #[cfg(feature = "cluster-async")]
 mod cluster_tokio;
 
+/// A module for Redis Cluster.
 #[cfg(any(feature = "cluster", feature = "cluster-async"))]
 pub mod cluster {
     #[cfg(feature = "cluster")]

--- a/src/pubsub_msg_std.rs
+++ b/src/pubsub_msg_std.rs
@@ -6,6 +6,7 @@ use redis::Msg;
 use sabi::{AsyncGroup, DataConn, DataSrc};
 use std::sync::Arc;
 
+/// A struct that holds a Redis Pub/Sub message as a data connection.
 pub struct RedisPubSubMsgDataConn {
     msg: Arc<Msg>,
 }
@@ -15,6 +16,11 @@ impl RedisPubSubMsgDataConn {
         Self { msg }
     }
 
+    /// Returns a reference to the underlying Redis Pub/Sub message.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the `redis::Msg`.
     pub fn get_message(&self) -> &Msg {
         &self.msg
     }
@@ -32,11 +38,21 @@ impl DataConn for RedisPubSubMsgDataConn {
     }
 }
 
+/// A struct that holds a Redis Pub/Sub message as a data source.
 pub struct RedisPubSubMsgDataSrc {
     msg: Arc<Msg>,
 }
 
 impl RedisPubSubMsgDataSrc {
+    /// Creates a new `RedisPubSubMsgDataSrc` with a Redis Pub/Sub message.
+    ///
+    /// # Arguments
+    ///
+    /// * `msg` - A `redis::Msg` received from a Pub/Sub subscriber.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisPubSubMsgDataSrc`.
     pub fn new(msg: Msg) -> Self {
         Self { msg: Arc::new(msg) }
     }

--- a/src/pubsub_msg_tokio.rs
+++ b/src/pubsub_msg_tokio.rs
@@ -6,6 +6,7 @@ use redis::Msg;
 use sabi::tokio::{AsyncGroup, DataConn, DataSrc};
 use std::sync::Arc;
 
+/// A struct that holds a Redis Pub/Sub message as an asynchronous data connection.
 pub struct RedisPubSubMsgDataConnAsync {
     msg: Arc<Msg>,
 }
@@ -15,6 +16,11 @@ impl RedisPubSubMsgDataConnAsync {
         Self { msg }
     }
 
+    /// Returns a reference to the underlying Redis Pub/Sub message.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the `redis::Msg`.
     pub fn get_message(&self) -> &Msg {
         &self.msg
     }
@@ -33,11 +39,21 @@ impl DataConn for RedisPubSubMsgDataConnAsync {
     }
 }
 
+/// A struct that holds a Redis Pub/Sub message as an asynchronous data source.
 pub struct RedisPubSubMsgDataSrcAsync {
     msg: Arc<Msg>,
 }
 
 impl RedisPubSubMsgDataSrcAsync {
+    /// Creates a new `RedisPubSubMsgDataSrcAsync` with a Redis Pub/Sub message.
+    ///
+    /// # Arguments
+    ///
+    /// * `msg` - A `redis::Msg` received from an asynchronous Pub/Sub subscriber.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `RedisPubSubMsgDataSrcAsync`.
     pub fn new(msg: Msg) -> Self {
         Self { msg: Arc::new(msg) }
     }


### PR DESCRIPTION
This PR adds documentation comments to the public modules and the following items directly under `src/` directory:

- `RedisPubSubMsgDataConn`
- `RedisPubSubMsgDataSrc`
- `RedisPubSubMsgDataConnAsync`
- `RedisPubSubMsgDataSrcAsync`